### PR TITLE
Prompts fixes

### DIFF
--- a/generate_synthetic_table/prompts/academic.yaml
+++ b/generate_synthetic_table/prompts/academic.yaml
@@ -21,6 +21,16 @@ generate_qa: |
   - Is the reasoning process (Annotation) logically flawless?
   - Is the question clear and unambiguous? (e.g., "Best model" -> "Model with highest Accuracy")
 
+  ### [Answer Format Guidelines - CRITICAL FOR EVALUATION]
+  ⚠️ **Answers MUST be SHORT and CONCISE (단답형)** ⚠️
+  - **DO NOT include reasoning or explanation in the answer** - put those in reasoning_annotation only
+  - **Numeric answers**: Just the number with unit (e.g., "92.5%", "3.2M params", "15 epochs")
+  - **Yes/No questions**: "예" or "아니오" only
+  - **Entity answers**: Just the name (e.g., "Model-A", "Dataset-X")
+  - **List answers**: Comma-separated items only (e.g., "Model-A, Model-B")
+  - **Comparison answers**: Just the winner/result (e.g., "Proposed Method", "Baseline")
+  - **Maximum answer length: 50 characters**
+
   ### [Reasoning Type Definitions (Academic Domain)]
   (1) lookup: Retrieve specific model performance or value without condition/calculation. (e.g., "What is the Top-1 Accuracy of Model-A?")
   (2) filter: Select rows/columns meeting specific conditions (performance, params, etc.). (e.g., "List all models with parameters under 10M.")
@@ -37,7 +47,7 @@ generate_qa: |
     "qa_pairs": [
       {{
         "question": "Question text",
-        "answer": "Answer text",
+        "answer": "Short answer only (max 50 chars, no explanation)",
         "type": "lookup",
         "reasoning_annotation": "Step-by-step logic to derive answer (MUST be a string, not a list)",
         "context": null
@@ -66,6 +76,16 @@ generate_qa_from_image: |
   - Is the reasoning process (Annotation) logically flawless?
   - Is the question clear and unambiguous? (e.g., "Best model" -> "Model with highest Accuracy")
 
+  ### [Answer Format Guidelines - CRITICAL FOR EVALUATION]
+  ⚠️ **Answers MUST be SHORT and CONCISE (단답형)** ⚠️
+  - **DO NOT include reasoning or explanation in the answer** - put those in reasoning_annotation only
+  - **Numeric answers**: Just the number with unit (e.g., "92.5%", "3.2M params", "15 epochs")
+  - **Yes/No questions**: "예" or "아니오" only
+  - **Entity answers**: Just the name (e.g., "Model-A", "Dataset-X")
+  - **List answers**: Comma-separated items only (e.g., "Model-A, Model-B")
+  - **Comparison answers**: Just the winner/result (e.g., "Proposed Method", "Baseline")
+  - **Maximum answer length: 50 characters**
+
   ### [Reasoning Type Definitions (Academic Domain)]
   (1) lookup: Retrieve specific model performance or value without condition/calculation. (e.g., "What is the Top-1 Accuracy of Model-A?")
   (2) filter: Select rows/columns meeting specific conditions (performance, params, etc.). (e.g., "List all models with parameters under 10M.")
@@ -82,7 +102,7 @@ generate_qa_from_image: |
     "qa_pairs": [
       {{
         "question": "Question text",
-        "answer": "Answer text",
+        "answer": "Short answer only (max 50 chars, no explanation)",
         "type": "lookup",
         "reasoning_annotation": "Step-by-step logic to derive answer (MUST be a string, not a list)",
         "context": null
@@ -117,6 +137,13 @@ generate_qa_from_multi_image: |
   - Is the reasoning process logically flawless?
   - Is the question clear about what experimental data is being compared or combined?
 
+  ### [Answer Format Guidelines - CRITICAL FOR EVALUATION]
+  ⚠️ **Answers MUST be SHORT and CONCISE (단답형)** ⚠️
+  - **DO NOT include reasoning or explanation in the answer** - put those in reasoning_annotation only
+  - **Numeric answers**: Just the number with unit (e.g., "92.5%", "3.2M params")
+  - **Entity answers**: Just the name (e.g., "Model-A", "Table 1")
+  - **Maximum answer length: 50 characters**
+
   ### [Cross-Image Reasoning Type Definitions (Academic Domain)]
   (1) cross_lookup: Retrieve and combine performance values from different result tables. (e.g., "What is Model-A's accuracy on both Dataset-X and Dataset-Y from the two tables?")
   (2) cross_filter: Filter models across benchmark tables based on conditions. (e.g., "Which models achieve >90% accuracy on both datasets shown in the two images?")
@@ -133,7 +160,7 @@ generate_qa_from_multi_image: |
     "qa_pairs": [
       {{
         "question": "Question requiring multiple academic images to answer",
-        "answer": "Answer derived from multiple images",
+        "answer": "Short answer only (max 50 chars)",
         "type": "cross_lookup",
         "reasoning_annotation": "Step 1: From Image 1, extract X. Step 2: From Image 2, extract Y. Step 3: Combine to get answer.",
         "context": null,
@@ -237,26 +264,38 @@ generate_long_sequence: |
   2. **Create a realistic academic context** (e.g., "Experimental Setup", "Research Hypothesis", "Ablation Study Goals") that provides information needed to answer the question.
   3. **The question must be unanswerable without the context** - the context should contain key criteria or conditions.
   4. **Strict Constraints**:
-     - Answer must be derived from BOTH the table AND the context. Neither alone is sufficient.
+     - Answer must be derived from BOTH the table AND the embedded context in the question. Neither alone is sufficient.
      - Questions and Answers MUST be written in Korean.
      - reasoning_annotation MUST be written in English and MUST be a single string.
-     - Context must be written in Korean and be 2-4 sentences long.
      - **DO NOT use real model/dataset names** (e.g., BERT, GPT, ResNet). Use fictional names.
+     - **context field should be null** - all context should be embedded within the question itself.
+  5. **Answer Format (단답형)**:
+     - Answers MUST be SHORT and CONCISE (max 50 characters)
+     - DO NOT include reasoning in the answer - put those in reasoning_annotation
+     - ❌ BAD: "조건을 충족하는 모델은 Model-A와 Model-B입니다."
+     - ✅ GOOD: "Model-A"
+  6. **⚠️ Question Length - CRITICAL ⚠️**:
+     - **Question MUST be at least 500 characters long (minimum 500자)**
+     - Create a realistic research scenario with specific situation, constraints, and requirements
+     - The question should ask to SELECT ONE specific item that best fits the given scenario
+     - ❌ BAD: Questions asking to count items or list multiple answers
+     - ✅ GOOD: Questions asking "which ONE model/method best fits this scenario?"
 
-  ### [Example Scenarios (Academic)]
-  - Context describes experimental conditions (dataset size, hardware) → Question asks which models meet the criteria
-  - Context outlines baseline comparison requirements → Question asks which methods show improvement
-  - Context specifies evaluation metrics of interest → Question asks for rankings based on those metrics
+  ### [Example Scenarios (Academic) - SELECT ONE ITEM]
+  - Research direction scenario: "연구 방향이 X로 변경되었을 때, 가장 적합한 실험 방법론은?"
+  - Resource constraint: "GPU 메모리가 제한적일 때, 가장 효율적인 모델 구성은?"
+  - Benchmark requirement: "새로운 벤치마크 기준을 충족해야 할 때, 우선 적용할 기법은?"
+  - Ablation study: "성능 저하를 최소화하면서 모델을 경량화할 때, 제거해야 할 컴포넌트는?"
 
   ### [Output Format (JSON)]
   {{
     "qa_pairs": [
       {{
-        "question": "Question requiring context to answer",
-        "answer": "Answer derived from table + context",
+        "question": "(MINIMUM 500자) 예시: 연구팀은 최근 학회 제출 마감을 앞두고 모델 성능 개선을 위한 긴급 실험을 계획하고 있다. 지도교수는 현재 가용한 컴퓨팅 자원이 제한적이며, 새로운 대규모 실험보다는 기존 실험 결과를 바탕으로 빠르게 개선점을 찾아야 한다고 강조하였다. 또한 공동 연구자는 ablation study 결과를 참고하여 핵심 컴포넌트를 파악하고, 가장 효과적인 개선 방향을 도출해야 한다고 의견을 제시하였다. 추가로 학회 규정상 파라미터 수가 10M 이하인 경량 모델만 제출 가능하다는 제약 조건이 있다. 현재 실험 결과 테이블에서 파라미터 제약을 충족하면서 베이스라인 대비 성능 향상이 가장 큰 방법론을 찾아 답하시오.",
+        "answer": "해당 방법론명 (max 50 chars)",
         "type": "long_sequence",
-        "reasoning_annotation": "Step 1: Extract key criteria from context. Step 2: Apply criteria to table. Step 3: Derive answer.",
-        "context": "실험 설정에 따르면... (2-4 sentences of academic context in Korean)"
+        "reasoning_annotation": "Step 1: Identify constraints from scenario (parameter limit, best improvement). Step 2: Filter models meeting parameter constraint. Step 3: Compare performance improvements. Step 4: Select the ONE best method.",
+        "context": null
       }}
     ]
   }}

--- a/generate_synthetic_table/prompts/business.yaml
+++ b/generate_synthetic_table/prompts/business.yaml
@@ -21,6 +21,20 @@ generate_qa: |
   - Is the reasoning process (Annotation) logically flawless?
   - Is the question clear and unambiguous? (e.g., "Best performance" -> "Branch with highest Revenue")
 
+  ### [Answer Format Guidelines - CRITICAL FOR EVALUATION]
+  ⚠️ **Answers MUST be SHORT and CONCISE (단답형)** ⚠️
+  - **DO NOT include reasoning or explanation in the answer** - put those in reasoning_annotation only
+  - **Numeric answers**: Just the number with unit (e.g., "150억원", "23.5%", "3개")
+  - **Yes/No questions**: "예" or "아니오" only
+  - **Entity answers**: Just the name (e.g., "마케팅팀", "A사", "김철수")
+  - **List answers**: Comma-separated items only (e.g., "A팀, B팀, C팀")
+  - **Comparison answers**: Just the winner/result (e.g., "영업팀", "2023년")
+  - **Maximum answer length: 50 characters**
+  - ❌ BAD: "총 6개입니다. 차별화 요소에 3개, 경쟁 우위에 3개가 있습니다."
+  - ✅ GOOD: "6개"
+  - ❌ BAD: "경쟁 우위가 비용 효율화를 더 구체적으로 다루고 있습니다. 왜냐하면..."
+  - ✅ GOOD: "경쟁 우위"
+
   ### [Reasoning Type Definitions (Business Domain)]
   (1) lookup: Retrieve specific performance values of departments or products without condition/calculation. (e.g., "What is the Q1 Revenue of Branch A?")
   (2) filter: Select rows/columns meeting specific conditions (goals met, budget range). (e.g., "List all products with operating margin over 20%.")
@@ -37,7 +51,7 @@ generate_qa: |
     "qa_pairs": [
       {{
         "question": "Question text",
-        "answer": "Answer text",
+        "answer": "Short answer only (max 50 chars, no explanation)",
         "type": "lookup",
         "reasoning_annotation": "Step-by-step logic to derive answer (MUST be a string, not a list)",
         "context": null
@@ -66,6 +80,20 @@ generate_qa_from_image: |
   - Is the reasoning process (Annotation) logically flawless?
   - Is the question clear and unambiguous? (e.g., "Best performance" -> "Branch with highest Revenue")
 
+  ### [Answer Format Guidelines - CRITICAL FOR EVALUATION]
+  ⚠️ **Answers MUST be SHORT and CONCISE (단답형)** ⚠️
+  - **DO NOT include reasoning or explanation in the answer** - put those in reasoning_annotation only
+  - **Numeric answers**: Just the number with unit (e.g., "150억원", "23.5%", "3개")
+  - **Yes/No questions**: "예" or "아니오" only
+  - **Entity answers**: Just the name (e.g., "마케팅팀", "A사", "김철수")
+  - **List answers**: Comma-separated items only (e.g., "A팀, B팀, C팀")
+  - **Comparison answers**: Just the winner/result (e.g., "영업팀", "2023년")
+  - **Maximum answer length: 50 characters**
+  - ❌ BAD: "총 6개입니다. 차별화 요소에 3개, 경쟁 우위에 3개가 있습니다."
+  - ✅ GOOD: "6개"
+  - ❌ BAD: "경쟁 우위가 비용 효율화를 더 구체적으로 다루고 있습니다. 왜냐하면..."
+  - ✅ GOOD: "경쟁 우위"
+
   ### [Reasoning Type Definitions (Business Domain)]
   (1) lookup: Retrieve specific performance values of departments or products without condition/calculation. (e.g., "What is the Q1 Revenue of Branch A?")
   (2) filter: Select rows/columns meeting specific conditions (goals met, budget range). (e.g., "List all products with operating margin over 20%.")
@@ -82,7 +110,7 @@ generate_qa_from_image: |
     "qa_pairs": [
       {{
         "question": "Question text",
-        "answer": "Answer text",
+        "answer": "Short answer only (max 50 chars, no explanation)",
         "type": "lookup",
         "reasoning_annotation": "Step-by-step logic to derive answer (MUST be a string, not a list)",
         "context": null
@@ -117,6 +145,16 @@ generate_qa_from_multi_image: |
   - Is the reasoning process logically flawless?
   - Is the question clear about what is being compared or combined?
 
+  ### [Answer Format Guidelines - CRITICAL FOR EVALUATION]
+  ⚠️ **Answers MUST be SHORT and CONCISE (단답형)** ⚠️
+  - **DO NOT include reasoning or explanation in the answer** - put those in reasoning_annotation only
+  - **Numeric answers**: Just the number with unit (e.g., "150억원", "23.5%", "3개")
+  - **Yes/No questions**: "예" or "아니오" only
+  - **Entity answers**: Just the name (e.g., "마케팅팀", "A사", "김철수")
+  - **List answers**: Comma-separated items only (e.g., "A팀, B팀, C팀")
+  - **Comparison answers**: Just the winner/result (e.g., "Table 1", "영업팀")
+  - **Maximum answer length: 50 characters**
+
   ### [Cross-Image Reasoning Type Definitions (Business Domain)]
   (1) cross_lookup: Retrieve and combine specific values from different images. (e.g., "What is the total Q1 revenue of Branch A from both Table 1 and Table 2?")
   (2) cross_filter: Filter rows across tables based on conditions spanning multiple images. (e.g., "Which departments appear in both tables and have positive profit margins in both?")
@@ -133,7 +171,7 @@ generate_qa_from_multi_image: |
     "qa_pairs": [
       {{
         "question": "Question requiring multiple images to answer",
-        "answer": "Answer derived from multiple images",
+        "answer": "Short answer only (max 50 chars, no explanation)",
         "type": "cross_lookup",
         "reasoning_annotation": "Step 1: From Image 1, extract X. Step 2: From Image 2, extract Y. Step 3: Combine to get answer.",
         "context": null,
@@ -248,26 +286,38 @@ generate_long_sequence: |
   2. **Create a realistic business context** (e.g., "Management Goals", "Market Conditions", "Strategic Guidelines") that provides information needed to answer the question.
   3. **The question must be unanswerable without the context** - the context should contain key criteria or conditions.
   4. **Strict Constraints**:
-     - Answer must be derived from BOTH the table AND the context. Neither alone is sufficient.
+     - Answer must be derived from BOTH the table AND the embedded context in the question. Neither alone is sufficient.
      - Questions and Answers MUST be written in Korean.
      - reasoning_annotation MUST be written in English and MUST be a single string.
-     - Context must be written in Korean and be 2-4 sentences long.
      - **DO NOT use real company names** (e.g., Samsung, Apple, Google). Use fictional names.
+     - **context field should be null** - all context should be embedded within the question itself.
+  5. **Answer Format (단답형)**:
+     - Answers MUST be SHORT and CONCISE (max 50 characters)
+     - DO NOT include reasoning in the answer - put those in reasoning_annotation
+     - ❌ BAD: "조건을 충족하는 팀은 A팀과 B팀입니다. 왜냐하면..."
+     - ✅ GOOD: "A팀, B팀"
+  6. **⚠️ Question Length - CRITICAL ⚠️**:
+     - **Question MUST be at least 500 characters long (minimum 500자)**
+     - Create a realistic business scenario with specific situation, constraints, and requirements
+     - The question should ask to SELECT ONE specific item/strategy that best fits the given scenario
+     - ❌ BAD: Questions asking to count items or list multiple answers
+     - ✅ GOOD: Questions asking "which ONE item best fits this scenario?"
 
-  ### [Example Scenarios (Business)]
-  - Context describes a target market condition → Question asks which products/departments meet the criteria
-  - Context outlines budget constraints → Question asks which projects are feasible
-  - Context specifies performance thresholds → Question asks which teams qualify
+  ### [Example Scenarios (Business) - SELECT ONE ITEM]
+  - New CEO scenario: "신임 CEO가 취임하며 X 방향을 제시했을 때, 가장 부합하는 전략은?"
+  - Crisis scenario: "경쟁사가 Y 공격을 해왔을 때, 우선적으로 활용해야 할 경쟁력은?"
+  - Resource constraint: "예산과 인력이 제한적일 때, 가장 먼저 추진해야 할 항목은?"
+  - Market change: "시장 트렌드가 Z로 변화했을 때, 가장 적합한 대응 전략은?"
 
   ### [Output Format (JSON)]
   {{
     "qa_pairs": [
       {{
-        "question": "Question requiring context to answer",
-        "answer": "Answer derived from table + context",
+        "question": "(MINIMUM 500자) 예시: A사는 최근 주력 사업 분야에서 경쟁사 B사의 공격적인 가격 인하 정책으로 인해 시장 점유율이 15% 하락하는 위기 상황에 직면하였다. 이에 경영진은 긴급 전략 회의를 소집하여 현재 보유한 경쟁력 요소들을 검토하고 있다. 회의에서 CFO는 현재 가용 예산이 제한적이며 신규 투자보다는 기존 역량을 활용한 즉각적인 대응이 필요하다고 강조하였다. 또한 CMO는 고객 이탈을 방지하기 위해 단기간 내에 가시적인 성과를 낼 수 있는 전략이 우선되어야 한다고 의견을 제시하였다. 이러한 상황에서 A사가 B사의 가격 공세에 대응하면서도 추가 비용 투입 없이 기존 인프라와 역량만으로 즉시 실행 가능한 전략 항목을 표에서 찾아 답하시오.",
+        "answer": "해당 전략 항목명 (max 50 chars)",
         "type": "long_sequence",
-        "reasoning_annotation": "Step 1: Extract key criteria from context. Step 2: Apply criteria to table. Step 3: Derive answer.",
-        "context": "경영 목표에 따르면... (2-4 sentences of business context in Korean)"
+        "reasoning_annotation": "Step 1: Identify key constraints from scenario (budget limited, need immediate results, use existing capabilities). Step 2: Evaluate each table item against these criteria. Step 3: Select the ONE item that best matches all conditions.",
+        "context": null
       }}
     ]
   }}

--- a/generate_synthetic_table/prompts/finance.yaml
+++ b/generate_synthetic_table/prompts/finance.yaml
@@ -14,12 +14,22 @@ generate_qa: |
      - Output format must strictly follow JSON.
      - Questions and Answers MUST be written in Korean.
      - reasoning_annotation MUST be written in English and MUST be a single string (not a list).
-     - **DO NOT use real company names** (e.g., Samsung, Apple, Google, 현대, SK). Use fictional names like "A사", "B기업", "가나다 주식회사".
+     - **DO NOT use real company/financial institution names** (e.g., Samsung, Apple, Google, 현대, SK, 국민은행, 신한은행, 하나은행, 우리은행, 삼성생명, 한화생명, 삼성화재, 현대해상, DB손해보험, 메리츠화재, KB손해보험, 삼성증권, 미래에셋증권, NH투자증권). Use fictional names like "A사", "B은행", "가나다증권", "라마바생명".
 
   ### [Validation Criteria]
   - Is the answer uniquely determined within the table?
   - Is the reasoning process (Annotation) logically flawless?
   - Is the question clear and unambiguous? (e.g., "Most undervalued stock" -> "Stock with lowest PER")
+
+  ### [Answer Format Guidelines - CRITICAL FOR EVALUATION]
+  ⚠️ **Answers MUST be SHORT and CONCISE (단답형)** ⚠️
+  - **DO NOT include reasoning or explanation in the answer** - put those in reasoning_annotation only
+  - **Numeric answers**: Just the number with unit (e.g., "150억원", "23.5%", "PER 12.5")
+  - **Yes/No questions**: "예" or "아니오" only
+  - **Entity answers**: Just the name (e.g., "A사", "B펀드")
+  - **List answers**: Comma-separated items only (e.g., "A사, B사, C사")
+  - **Comparison answers**: Just the winner/result (e.g., "A사", "2023년 Q4")
+  - **Maximum answer length: 50 characters**
 
   ### [Reasoning Type Definitions (Finance Domain)]
   (1) lookup: Retrieve specific stock price or financial figures without condition/calculation. (e.g., "What is Company A's 2023 dividend?")
@@ -37,7 +47,7 @@ generate_qa: |
     "qa_pairs": [
       {{
         "question": "Question text",
-        "answer": "Answer text",
+        "answer": "Short answer only (max 50 chars, no explanation)",
         "type": "lookup",
         "reasoning_annotation": "Step-by-step logic to derive answer (MUST be a string, not a list)",
         "context": null
@@ -59,12 +69,22 @@ generate_qa_from_image: |
      - Output format must strictly follow JSON.
      - Questions and Answers MUST be written in Korean.
      - reasoning_annotation MUST be written in English and MUST be a single string (not a list).
-     - **DO NOT use real company names** (e.g., Samsung, Apple, Google, 현대, SK). Use fictional names like "A사", "B기업", "가나다 주식회사".
+     - **DO NOT use real company/financial institution names** (e.g., Samsung, Apple, Google, 현대, SK, 국민은행, 신한은행, 하나은행, 우리은행, 삼성생명, 한화생명, 삼성화재, 현대해상, DB손해보험, 메리츠화재, KB손해보험, 삼성증권, 미래에셋증권, NH투자증권). Use fictional names like "A사", "B은행", "가나다증권", "라마바생명".
 
   ### [Validation Criteria]
   - Is the answer uniquely determined within the table?
   - Is the reasoning process (Annotation) logically flawless?
   - Is the question clear and unambiguous? (e.g., "Most undervalued stock" -> "Stock with lowest PER")
+
+  ### [Answer Format Guidelines - CRITICAL FOR EVALUATION]
+  ⚠️ **Answers MUST be SHORT and CONCISE (단답형)** ⚠️
+  - **DO NOT include reasoning or explanation in the answer** - put those in reasoning_annotation only
+  - **Numeric answers**: Just the number with unit (e.g., "150억원", "23.5%", "PER 12.5")
+  - **Yes/No questions**: "예" or "아니오" only
+  - **Entity answers**: Just the name (e.g., "A사", "B펀드")
+  - **List answers**: Comma-separated items only (e.g., "A사, B사, C사")
+  - **Comparison answers**: Just the winner/result (e.g., "A사", "2023년 Q4")
+  - **Maximum answer length: 50 characters**
 
   ### [Reasoning Type Definitions (Finance Domain)]
   (1) lookup: Retrieve specific stock price or financial figures without condition/calculation. (e.g., "What is Company A's 2023 dividend?")
@@ -82,7 +102,7 @@ generate_qa_from_image: |
     "qa_pairs": [
       {{
         "question": "Question text",
-        "answer": "Answer text",
+        "answer": "Short answer only (max 50 chars, no explanation)",
         "type": "lookup",
         "reasoning_annotation": "Step-by-step logic to derive answer (MUST be a string, not a list)",
         "context": null
@@ -110,12 +130,19 @@ generate_qa_from_multi_image: |
      - Output format must strictly follow JSON.
      - Questions and Answers MUST be written in Korean.
      - reasoning_annotation MUST be written in English, MUST be a single string, and MUST specify which images were used.
-     - **DO NOT use real company/fund names** (e.g., Samsung, Apple, Vanguard). Use fictional names like "A사", "B펀드", "가나다증권".
+     - **DO NOT use real company/financial institution/fund names** (e.g., Samsung, Apple, Vanguard, 국민은행, 신한은행, 하나은행, 우리은행, 삼성생명, 한화생명, 삼성화재, 현대해상, DB손해보험, 메리츠화재, KB손해보험, 삼성증권, 미래에셋). Use fictional names like "A사", "B은행", "C펀드", "가나다증권", "라마바생명".
 
   ### [Validation Criteria]
   - Does the answer REQUIRE data from multiple images? (Single-image answers are INVALID)
   - Is the reasoning process logically flawless?
   - Is the question clear about what is being compared or combined?
+
+  ### [Answer Format Guidelines - CRITICAL FOR EVALUATION]
+  ⚠️ **Answers MUST be SHORT and CONCISE (단답형)** ⚠️
+  - **DO NOT include reasoning or explanation in the answer** - put those in reasoning_annotation only
+  - **Numeric answers**: Just the number with unit (e.g., "150억원", "23.5%")
+  - **Entity answers**: Just the name (e.g., "A사", "Table 1")
+  - **Maximum answer length: 50 characters**
 
   ### [Cross-Image Reasoning Type Definitions (Finance Domain)]
   (1) cross_lookup: Retrieve and combine specific financial values from different statements. (e.g., "What is the total assets combining both Q1 and Q2 balance sheets?")
@@ -133,7 +160,7 @@ generate_qa_from_multi_image: |
     "qa_pairs": [
       {{
         "question": "Question requiring multiple financial images to answer",
-        "answer": "Answer derived from multiple images",
+        "answer": "Short answer only (max 50 chars)",
         "type": "cross_lookup",
         "reasoning_annotation": "Step 1: From Image 1, extract X. Step 2: From Image 2, extract Y. Step 3: Combine to get answer.",
         "context": null,
@@ -163,8 +190,8 @@ generate_synthetic_table: |
   3. **⚠️ Data Transformation - ABSOLUTELY MANDATORY ⚠️:**
      - **ALL data cell values MUST be replaced with completely new synthetic values.**
      - **NEVER copy any original data values** - generate fresh, realistic alternatives.
-     - **NEVER use real company/brand names** (Samsung, Apple, Google, 현대, SK, LG, etc.). Use fictional names like "A사", "가나다 기업", "XYZ Corp".
-     - For company names: Generate DIFFERENT fictional names (e.g., "A회사" → "B회사")
+     - **NEVER use real company/financial institution names** (Samsung, Apple, Google, 현대, SK, LG, 국민은행, 신한은행, 하나은행, 우리은행, 삼성생명, 한화생명, 삼성화재, 현대해상, DB손해보험, 메리츠화재, KB손해보험, 삼성증권, 미래에셋증권, NH투자증권, etc.). Use fictional names like "A사", "B은행", "가나다증권", "라마바생명".
+     - For company/institution names: Generate DIFFERENT fictional names (e.g., "A회사" → "B회사", "가나다은행" → "라마바은행")
      - For financial figures: Generate DIFFERENT amounts (similar magnitude, different values)
      - For percentages/ratios: Generate DIFFERENT metrics
      - For dates: Generate DIFFERENT plausible dates
@@ -203,8 +230,8 @@ generate_synthetic_table_from_image: |
   3. **⚠️ Data Generation - ABSOLUTELY CRITICAL ⚠️:**
      - **NEVER copy the data values from the image** - this is NOT an OCR task
      - **ALL cell content must be completely NEW and DIFFERENT**
-     - **NEVER use real company/brand names** (Samsung, Apple, Google, 현대, SK, LG, etc.). Use fictional names like "A사", "가나다 기업", "XYZ Corp".
-     - For company names: Generate DIFFERENT fictional names
+     - **NEVER use real company/financial institution names** (Samsung, Apple, Google, 현대, SK, LG, 국민은행, 신한은행, 하나은행, 우리은행, 삼성생명, 한화생명, 삼성화재, 현대해상, DB손해보험, 메리츠화재, KB손해보험, 삼성증권, 미래에셋증권, NH투자증권, etc.). Use fictional names like "A사", "B은행", "가나다증권", "라마바생명".
+     - For company/institution names: Generate DIFFERENT fictional names
      - For financial figures: Generate DIFFERENT amounts
      - For percentages/ratios: Generate DIFFERENT metrics
   4. **Styling:** Use **Tailwind CSS** classes exclusively (NO inline styles).
@@ -236,26 +263,38 @@ generate_long_sequence: |
   2. **Create a realistic financial context** (e.g., "Market Outlook", "Investment Strategy", "Risk Guidelines") that provides information needed to answer the question.
   3. **The question must be unanswerable without the context** - the context should contain key criteria or conditions.
   4. **Strict Constraints**:
-     - Answer must be derived from BOTH the table AND the context. Neither alone is sufficient.
+     - Answer must be derived from BOTH the table AND the embedded context in the question. Neither alone is sufficient.
      - Questions and Answers MUST be written in Korean.
      - reasoning_annotation MUST be written in English and MUST be a single string.
-     - Context must be written in Korean and be 2-4 sentences long.
-     - **DO NOT use real company names** (e.g., Samsung, Apple, Google). Use fictional names.
+     - **DO NOT use real company/financial institution names** (e.g., Samsung, Apple, Google, 국민은행, 신한은행, 하나은행, 우리은행, 삼성생명, 한화생명, 삼성화재, 현대해상, DB손해보험, 메리츠화재, KB손해보험, 삼성증권, 미래에셋). Use fictional names like "A사", "B은행", "가나다증권", "라마바생명".
+     - **context field should be null** - all context should be embedded within the question itself.
+  5. **Answer Format (단답형)**:
+     - Answers MUST be SHORT and CONCISE (max 50 characters)
+     - DO NOT include reasoning in the answer - put those in reasoning_annotation
+     - ❌ BAD: "조건을 충족하는 종목은 A사와 B사입니다."
+     - ✅ GOOD: "A사"
+  6. **⚠️ Question Length - CRITICAL ⚠️**:
+     - **Question MUST be at least 500 characters long (minimum 500자)**
+     - Create a realistic investment/financial scenario with specific situation, constraints, and requirements
+     - The question should ask to SELECT ONE specific item that best fits the given scenario
+     - ❌ BAD: Questions asking to count items or list multiple answers
+     - ✅ GOOD: Questions asking "which ONE stock/fund best fits this scenario?"
 
-  ### [Example Scenarios (Finance)]
-  - Context describes investment criteria (PER < 15, ROE > 10%) → Question asks which stocks qualify
-  - Context outlines risk tolerance levels → Question asks which portfolio allocation is appropriate
-  - Context specifies sector preferences → Question asks which companies match the strategy
+  ### [Example Scenarios (Finance) - SELECT ONE ITEM]
+  - Market downturn scenario: "시장 급락 상황에서 포트폴리오 방어를 위해 가장 먼저 매도해야 할 종목은?"
+  - Investment mandate: "보수적 투자 성향의 고객에게 추천할 가장 적합한 상품은?"
+  - Risk management: "리스크 한도를 초과했을 때, 가장 먼저 축소해야 할 포지션은?"
+  - Regulatory compliance: "새로운 규제 요건을 충족하기 위해 조정해야 할 항목은?"
 
   ### [Output Format (JSON)]
   {{
     "qa_pairs": [
       {{
-        "question": "Question requiring context to answer",
-        "answer": "Answer derived from table + context",
+        "question": "(MINIMUM 500자) 예시: 자산운용사 A펀드는 최근 글로벌 금리 인상과 경기 침체 우려로 인해 포트폴리오 리밸런싱을 검토하고 있다. 리스크관리팀은 현재 포트폴리오의 변동성이 내부 기준치를 초과하였으며, 방어적 자산 비중을 높여야 한다고 보고하였다. CIO는 유동성을 확보하면서도 장기 수익률 목표를 훼손하지 않는 방향으로 조정이 필요하다고 지시하였다. 추가로 내부 규정상 단일 종목 비중이 15%를 초과하는 경우 우선 매도 대상이 된다. 현재 보유 종목 중에서 비중 규정을 위반하면서 변동성이 가장 높아 즉시 매도가 필요한 종목을 찾아 답하시오.",
+        "answer": "해당 종목명 (max 50 chars)",
         "type": "long_sequence",
-        "reasoning_annotation": "Step 1: Extract key criteria from context. Step 2: Apply criteria to table. Step 3: Derive answer.",
-        "context": "투자 전략에 따르면... (2-4 sentences of financial context in Korean)"
+        "reasoning_annotation": "Step 1: Identify constraints from scenario (weight limit, high volatility). Step 2: Filter stocks exceeding 15% weight. Step 3: Compare volatility among filtered stocks. Step 4: Select the ONE stock that needs immediate sale.",
+        "context": null
       }}
     ]
   }}

--- a/generate_synthetic_table/prompts/insurance.yaml
+++ b/generate_synthetic_table/prompts/insurance.yaml
@@ -15,14 +15,22 @@ generate_qa: |
   3. **Language:** The questions and answers MUST be in Korean.
   4. **Reasoning Language:** reasoning_annotation MUST be written in English and MUST be a single string (not a list).
   5. **Accuracy:** Ensure all answers are factually correct based on the data in the table.
-  7. **Context:** Include the specific table cells or rows that were used to answer the question.
+  6. **Context:** Include the specific table cells or rows that were used to answer the question.
+  7. **⚠️ Answer Format (단답형) - CRITICAL FOR EVALUATION ⚠️:**
+      - Answers MUST be SHORT and CONCISE (max 50 characters)
+      - **Numeric answers**: Just the number with unit (e.g., "1억원", "월 5만원", "80%")
+      - **Yes/No**: "예" or "아니오" only
+      - **Entity answers**: Just the name (e.g., "프리미엄 플랜", "암 특약")
+      - **Comparison**: Just the winner (e.g., "플랜A", "골드형")
+      - ❌ BAD: "플랜A의 자기부담금은 10만원입니다."
+      - ✅ GOOD: "10만원"
 
   **Output Format (JSON):**
   {{
       "qa_pairs": [
           {{
               "question": "...",
-              "answer": "...",
+              "answer": "Short answer only (max 50 chars)",
               "type": "lookup",
               "reasoning_annotation": "Detailed explanation of how the answer was derived (in English, single string)",
               "context": "Specific table cells/rows used (e.g., 'Row 2, Column 3: Premium amount')"
@@ -47,13 +55,20 @@ generate_qa_from_image: |
   5. **Reasoning Language:** reasoning_annotation MUST be written in English and MUST be a single string (not a list).
   6. **Accuracy:** Ensure 100% factual correctness.
   7. **Context:** Include specific cell references or table sections used to derive the answer.
+  8. **⚠️ Answer Format (단답형) - CRITICAL FOR EVALUATION ⚠️:**
+      - Answers MUST be SHORT and CONCISE (max 50 characters)
+      - **Numeric answers**: Just the number with unit (e.g., "1억원", "월 5만원")
+      - **Yes/No**: "예" or "아니오" only
+      - **Entity answers**: Just the name (e.g., "프리미엄 플랜")
+      - ❌ BAD: "플랜A의 보장한도는 1억원입니다."
+      - ✅ GOOD: "1억원"
 
   **Output Format (JSON):**
   {{
       "qa_pairs": [
           {{
               "question": "...",
-              "answer": "...",
+              "answer": "Short answer only (max 50 chars)",
               "type": "lookup",
               "reasoning_annotation": "Step-by-step reasoning process in English (single string)",
               "context": "Table location used (e.g., 'Premium column, Row 3')"
@@ -141,3 +156,51 @@ generate_synthetic_table_from_image: |
   - Amount in image: "금액A" → Generate: "금액B"
 
   ⚠️ If the generated content is identical or very similar to the image, the output is INVALID.
+
+generate_long_sequence: |
+  You are an expert in insurance policies, claims, and coverage analysis.
+  Your mission is to generate a single high-quality "long_sequence" type QA pair that requires interpreting external context to answer questions about the insurance table.
+
+  **Input Table:**
+  {synthetic_html}
+
+  ### [Instructions]
+  1. **Generate ONE long_sequence QA pair** that requires reading and understanding a context paragraph to filter or interpret the insurance data.
+  2. **Create a realistic insurance scenario** (e.g., "Customer Profile", "Claim Situation", "Coverage Needs") that provides information needed to answer the question.
+  3. **The question must be unanswerable without the context** - the context should contain key criteria or conditions.
+  4. **Strict Constraints**:
+     - Answer must be derived from BOTH the table AND the embedded context in the question. Neither alone is sufficient.
+     - Questions and Answers MUST be written in Korean.
+     - reasoning_annotation MUST be written in English and MUST be a single string.
+     - **context field should be null** - all context should be embedded within the question itself.
+  5. **Answer Format (단답형)**:
+     - Answers MUST be SHORT and CONCISE (max 50 characters)
+     - DO NOT include reasoning in the answer - put those in reasoning_annotation
+     - ❌ BAD: "고객의 조건에 맞는 상품은 프리미엄 플랜입니다."
+     - ✅ GOOD: "프리미엄 플랜"
+  6. **⚠️ Question Length - CRITICAL ⚠️**:
+     - **Question MUST be at least 500 characters long (minimum 500자)**
+     - Create a realistic insurance scenario with specific customer situation, needs, and constraints
+     - The question should ask to SELECT ONE specific plan/product that best fits the given scenario
+     - ❌ BAD: Questions asking to count items or list multiple answers
+     - ✅ GOOD: Questions asking "which ONE insurance product best fits this customer?"
+
+  ### [Example Scenarios (Insurance) - SELECT ONE ITEM]
+  - Claim scenario: "특정 사고 상황에서 보장받을 수 있는 담보 항목은?"
+  - Plan selection: "고객의 니즈에 가장 적합한 보험 상품은?"
+  - Coverage gap: "기존 보험으로 보장되지 않는 위험에 대비할 추가 특약은?"
+  - Premium optimization: "보험료 부담을 줄이면서 핵심 보장을 유지할 수 있는 플랜은?"
+
+  ### [Output Format (JSON)]
+  {{
+    "qa_pairs": [
+      {{
+        "question": "(MINIMUM 500자) 예시: 보험설계사는 40대 가장인 고객의 보험 포트폴리오 재설계를 진행하고 있다. 고객은 현재 월 보험료 부담이 크다고 느끼며, 자녀 교육비 증가로 인해 보험료를 월 20만원 이하로 줄이고 싶다고 요청하였다. 그러나 가장으로서 사망보장 1억원 이상과 중대질병 보장은 반드시 유지해야 한다고 강조하였다. 또한 최근 건강검진에서 고혈압 전단계 판정을 받아 향후 심혈관 질환에 대한 보장도 필요하다고 언급하였다. 현재 가입 가능한 보험 상품 중에서 고객의 모든 요구사항을 충족하는 상품을 찾아 답하시오.",
+        "answer": "해당 보험상품명 (max 50 chars)",
+        "type": "long_sequence",
+        "reasoning_annotation": "Step 1: Identify customer requirements from scenario (premium <= 200k, death benefit >= 100M, critical illness coverage, cardiovascular coverage). Step 2: Filter products meeting premium constraint. Step 3: Check coverage items among filtered products. Step 4: Select the ONE product meeting all requirements.",
+        "context": null
+      }}
+    ]
+  }}
+  Return ONLY the JSON object.

--- a/generate_synthetic_table/prompts/medical.yaml
+++ b/generate_synthetic_table/prompts/medical.yaml
@@ -22,6 +22,16 @@ generate_qa: |
   - Is the reasoning process (Annotation) logically flawless?
   - Is the question clear and unambiguous? (e.g., "Patient in bad condition" -> "Patient with systolic BP under 90mmHg")
 
+  ### [Answer Format Guidelines - CRITICAL FOR EVALUATION]
+  ⚠️ **Answers MUST be SHORT and CONCISE (단답형)** ⚠️
+  - **DO NOT include reasoning or explanation in the answer** - put those in reasoning_annotation only
+  - **Numeric answers**: Just the number with unit (e.g., "120/80mmHg", "38.5°C", "150mg/dL")
+  - **Yes/No questions**: "예" or "아니오" only
+  - **Entity answers**: Just the name (e.g., "환자ID-001", "약물-X", "A병원")
+  - **List answers**: Comma-separated items only (e.g., "환자-001, 환자-002")
+  - **Comparison answers**: Just the winner/result (e.g., "치료군", "Day 3")
+  - **Maximum answer length: 50 characters**
+
   ### [Reasoning Type Definitions (Medical Domain)]
   (1) lookup: Retrieve specific patient lab results or medication info without condition/calculation. (e.g., "What is the blood glucose level of Patient ID-001?")
   (2) filter: Select rows/columns meeting specific conditions (abnormal range, specific disease). (e.g., "List all patients with temperature above 38°C.")
@@ -38,7 +48,7 @@ generate_qa: |
     "qa_pairs": [
       {{
         "question": "Question text",
-        "answer": "Answer text",
+        "answer": "Short answer only (max 50 chars, no explanation)",
         "type": "lookup",
         "reasoning_annotation": "Step-by-step logic to derive answer (MUST be a string, not a list)",
         "context": null
@@ -67,6 +77,16 @@ generate_qa_from_image: |
   - Is the reasoning process (Annotation) logically flawless?
   - Is the question clear and unambiguous? (e.g., "Patient in bad condition" -> "Patient with systolic BP under 90mmHg")
 
+  ### [Answer Format Guidelines - CRITICAL FOR EVALUATION]
+  ⚠️ **Answers MUST be SHORT and CONCISE (단답형)** ⚠️
+  - **DO NOT include reasoning or explanation in the answer** - put those in reasoning_annotation only
+  - **Numeric answers**: Just the number with unit (e.g., "120/80mmHg", "38.5°C", "150mg/dL")
+  - **Yes/No questions**: "예" or "아니오" only
+  - **Entity answers**: Just the name (e.g., "환자ID-001", "약물-X", "A병원")
+  - **List answers**: Comma-separated items only (e.g., "환자-001, 환자-002")
+  - **Comparison answers**: Just the winner/result (e.g., "치료군", "Day 3")
+  - **Maximum answer length: 50 characters**
+
   ### [Reasoning Type Definitions (Medical Domain)]
   (1) lookup: Retrieve specific patient lab results or medication info without condition/calculation. (e.g., "What is the blood glucose level of Patient ID-001?")
   (2) filter: Select rows/columns meeting specific conditions (abnormal range, specific disease). (e.g., "List all patients with temperature above 38°C.")
@@ -83,7 +103,7 @@ generate_qa_from_image: |
     "qa_pairs": [
       {{
         "question": "Question text",
-        "answer": "Answer text",
+        "answer": "Short answer only (max 50 chars, no explanation)",
         "type": "lookup",
         "reasoning_annotation": "Step-by-step logic to derive answer",
         "context": null
@@ -118,6 +138,13 @@ generate_qa_from_multi_image: |
   - Is the reasoning process logically flawless?
   - Is the question clear about what clinical data is being compared or combined?
 
+  ### [Answer Format Guidelines - CRITICAL FOR EVALUATION]
+  ⚠️ **Answers MUST be SHORT and CONCISE (단답형)** ⚠️
+  - **DO NOT include reasoning or explanation in the answer** - put those in reasoning_annotation only
+  - **Numeric answers**: Just the number with unit (e.g., "120/80mmHg", "38.5°C")
+  - **Entity answers**: Just the name (e.g., "환자ID-001", "Table 1")
+  - **Maximum answer length: 50 characters**
+
   ### [Cross-Image Reasoning Type Definitions (Medical Domain)]
   (1) cross_lookup: Retrieve and combine patient data from different clinical records. (e.g., "What is the patient's blood glucose level before and after treatment from both tables?")
   (2) cross_filter: Filter patients across clinical datasets based on conditions. (e.g., "Which patients appear in both the treatment and follow-up tables with improved vitals?")
@@ -134,7 +161,7 @@ generate_qa_from_multi_image: |
     "qa_pairs": [
       {{
         "question": "Question requiring multiple clinical images to answer",
-        "answer": "Answer derived from multiple images",
+        "answer": "Short answer only (max 50 chars)",
         "type": "cross_lookup",
         "reasoning_annotation": "Step 1: From Image 1, extract X. Step 2: From Image 2, extract Y. Step 3: Combine to get answer.",
         "context": null,
@@ -237,26 +264,38 @@ generate_long_sequence: |
   2. **Create a realistic clinical context** (e.g., "Clinical Protocol", "Exclusion Criteria", "Treatment Guidelines") that provides information needed to answer the question.
   3. **The question must be unanswerable without the context** - the context should contain key criteria or conditions.
   4. **Strict Constraints**:
-     - Answer must be derived from BOTH the table AND the context. Neither alone is sufficient.
+     - Answer must be derived from BOTH the table AND the embedded context in the question. Neither alone is sufficient.
      - Questions and Answers MUST be written in Korean.
      - reasoning_annotation MUST be written in English and MUST be a single string.
-     - Context must be written in Korean and be 2-4 sentences long.
      - **DO NOT use real hospital/drug names**. Use fictional names like "A병원", "약물-X".
+     - **context field should be null** - all context should be embedded within the question itself.
+  5. **Answer Format (단답형)**:
+     - Answers MUST be SHORT and CONCISE (max 50 characters)
+     - DO NOT include reasoning in the answer - put those in reasoning_annotation
+     - ❌ BAD: "조건을 충족하는 환자는 환자-001과 환자-002입니다."
+     - ✅ GOOD: "환자ID-003"
+  6. **⚠️ Question Length - CRITICAL ⚠️**:
+     - **Question MUST be at least 500 characters long (minimum 500자)**
+     - Create a realistic clinical scenario with specific situation, constraints, and requirements
+     - The question should ask to SELECT ONE specific patient/treatment that best fits the given scenario
+     - ❌ BAD: Questions asking to count items or list multiple answers
+     - ✅ GOOD: Questions asking "which ONE patient needs immediate attention?"
 
-  ### [Example Scenarios (Medical)]
-  - Context describes patient exclusion criteria (age, comorbidities) → Question asks which patients are eligible
-  - Context outlines dosage adjustment rules → Question asks which patients need dose modification
-  - Context specifies lab value thresholds for intervention → Question asks which patients require treatment
+  ### [Example Scenarios (Medical) - SELECT ONE ITEM]
+  - Emergency triage: "응급 상황에서 가장 먼저 처치해야 할 환자는?"
+  - Drug interaction: "특정 약물을 복용 중인 환자에게 투여 가능한 대체 약물은?"
+  - Clinical trial: "임상시험 기준을 충족하는 환자 중 가장 적합한 대상자는?"
+  - Resource allocation: "ICU 병상이 부족할 때, 우선 전원해야 할 환자는?"
 
   ### [Output Format (JSON)]
   {{
     "qa_pairs": [
       {{
-        "question": "Question requiring context to answer",
-        "answer": "Answer derived from table + context",
+        "question": "(MINIMUM 500자) 예시: 종합병원 응급실에 다수의 환자가 동시에 내원하여 중증도 분류가 필요한 상황이다. 응급의학과 전문의는 현재 가용한 의료진과 장비가 제한적이며, 환자 상태에 따른 우선순위 결정이 시급하다고 판단하였다. 간호팀장은 활력징후와 의식 수준을 기준으로 즉각적인 처치가 필요한 환자를 선별해야 한다고 보고하였다. 내부 지침에 따르면 수축기 혈압 90mmHg 미만이면서 의식 저하가 동반된 경우 최우선 처치 대상이다. 현재 대기 중인 환자 목록에서 해당 기준을 충족하여 즉시 소생술이 필요한 환자를 찾아 답하시오.",
+        "answer": "해당 환자ID (max 50 chars)",
         "type": "long_sequence",
-        "reasoning_annotation": "Step 1: Extract key criteria from context. Step 2: Apply criteria to table. Step 3: Derive answer.",
-        "context": "임상 프로토콜에 따르면... (2-4 sentences of clinical context in Korean)"
+        "reasoning_annotation": "Step 1: Identify triage criteria from scenario (BP < 90mmHg, altered consciousness). Step 2: Filter patients meeting blood pressure criterion. Step 3: Check consciousness level among filtered patients. Step 4: Select the ONE patient requiring immediate resuscitation.",
+        "context": null
       }}
     ]
   }}

--- a/generate_synthetic_table/prompts/public.yaml
+++ b/generate_synthetic_table/prompts/public.yaml
@@ -21,6 +21,16 @@ generate_qa: |
   - Is the reasoning process (Annotation) logically flawless?
   - Is the question clear and unambiguous? (e.g., "Place with most people" -> "District with highest Population")
 
+  ### [Answer Format Guidelines - CRITICAL FOR EVALUATION]
+  ⚠️ **Answers MUST be SHORT and CONCISE (단답형)** ⚠️
+  - **DO NOT include reasoning or explanation in the answer** - put those in reasoning_annotation only
+  - **Numeric answers**: Just the number with unit (e.g., "150만명", "85.3%", "1,200억원")
+  - **Yes/No questions**: "예" or "아니오" only
+  - **Entity answers**: Just the name (e.g., "A시", "복지부", "나구")
+  - **List answers**: Comma-separated items only (e.g., "A시, B구, C군")
+  - **Comparison answers**: Just the winner/result (e.g., "A시", "2023년")
+  - **Maximum answer length: 50 characters**
+
   ### [Reasoning Type Definitions (Public Domain)]
   (1) lookup: Retrieve specific regional or annual statistics without condition/calculation. (e.g., "What is the total population of Region A in 2023?")
   (2) filter: Select rows/columns meeting specific conditions (above/below value, specific region). (e.g., "List all departments with budget execution rate over 90%.")
@@ -37,7 +47,7 @@ generate_qa: |
     "qa_pairs": [
       {{
         "question": "Question text",
-        "answer": "Answer text",
+        "answer": "Short answer only (max 50 chars, no explanation)",
         "type": "lookup",
         "reasoning_annotation": "Step-by-step logic to derive answer (MUST be a string, not a list)",
         "context": null
@@ -66,6 +76,16 @@ generate_qa_from_image: |
   - Is the reasoning process (Annotation) logically flawless?
   - Is the question clear and unambiguous? (e.g., "Place with most people" -> "District with highest Population")
 
+  ### [Answer Format Guidelines - CRITICAL FOR EVALUATION]
+  ⚠️ **Answers MUST be SHORT and CONCISE (단답형)** ⚠️
+  - **DO NOT include reasoning or explanation in the answer** - put those in reasoning_annotation only
+  - **Numeric answers**: Just the number with unit (e.g., "150만명", "85.3%", "1,200억원")
+  - **Yes/No questions**: "예" or "아니오" only
+  - **Entity answers**: Just the name (e.g., "A시", "복지부", "나구")
+  - **List answers**: Comma-separated items only (e.g., "A시, B구, C군")
+  - **Comparison answers**: Just the winner/result (e.g., "A시", "2023년")
+  - **Maximum answer length: 50 characters**
+
   ### [Reasoning Type Definitions (Public Domain)]
   (1) lookup: Retrieve specific regional or annual statistics without condition/calculation. (e.g., "What is the total population of Region A in 2023?")
   (2) filter: Select rows/columns meeting specific conditions (above/below value, specific region). (e.g., "List all departments with budget execution rate over 90%.")
@@ -82,7 +102,7 @@ generate_qa_from_image: |
     "qa_pairs": [
       {{
         "question": "Question text",
-        "answer": "Answer text",
+        "answer": "Short answer only (max 50 chars, no explanation)",
         "type": "lookup",
         "reasoning_annotation": "Step-by-step logic to derive answer",
         "context": null
@@ -117,6 +137,13 @@ generate_qa_from_multi_image: |
   - Is the reasoning process logically flawless?
   - Is the question clear about what public data is being compared or combined?
 
+  ### [Answer Format Guidelines - CRITICAL FOR EVALUATION]
+  ⚠️ **Answers MUST be SHORT and CONCISE (단답형)** ⚠️
+  - **DO NOT include reasoning or explanation in the answer** - put those in reasoning_annotation only
+  - **Numeric answers**: Just the number with unit (e.g., "150만명", "85.3%")
+  - **Entity answers**: Just the name (e.g., "A시", "Table 1")
+  - **Maximum answer length: 50 characters**
+
   ### [Cross-Image Reasoning Type Definitions (Public Domain)]
   (1) cross_lookup: Retrieve and combine regional statistics from different data tables. (e.g., "What is the total population of A시 combining both census tables?")
   (2) cross_filter: Filter regions across datasets based on conditions. (e.g., "Which districts appear in both tables with budget execution rate >80%?")
@@ -133,7 +160,7 @@ generate_qa_from_multi_image: |
     "qa_pairs": [
       {{
         "question": "Question requiring multiple public data images to answer",
-        "answer": "Answer derived from multiple images",
+        "answer": "Short answer only (max 50 chars)",
         "type": "cross_lookup",
         "reasoning_annotation": "Step 1: From Image 1, extract X. Step 2: From Image 2, extract Y. Step 3: Combine to get answer.",
         "context": null,
@@ -236,26 +263,38 @@ generate_long_sequence: |
   2. **Create a realistic public policy context** (e.g., "Policy Guidelines", "Legal Requirements", "Budget Allocation Rules") that provides information needed to answer the question.
   3. **The question must be unanswerable without the context** - the context should contain key criteria or conditions.
   4. **Strict Constraints**:
-     - Answer must be derived from BOTH the table AND the context. Neither alone is sufficient.
+     - Answer must be derived from BOTH the table AND the embedded context in the question. Neither alone is sufficient.
      - Questions and Answers MUST be written in Korean.
      - reasoning_annotation MUST be written in English and MUST be a single string.
-     - Context must be written in Korean and be 2-4 sentences long.
      - **DO NOT use real place names** (e.g., Seoul, Busan). Use fictional names.
+     - **context field should be null** - all context should be embedded within the question itself.
+  5. **Answer Format (단답형)**:
+     - Answers MUST be SHORT and CONCISE (max 50 characters)
+     - DO NOT include reasoning in the answer - put those in reasoning_annotation
+     - ❌ BAD: "조건을 충족하는 지역은 A시와 B구입니다."
+     - ✅ GOOD: "A시"
+  6. **⚠️ Question Length - CRITICAL ⚠️**:
+     - **Question MUST be at least 500 characters long (minimum 500자)**
+     - Create a realistic policy/administrative scenario with specific situation, constraints, and requirements
+     - The question should ask to SELECT ONE specific region/department that best fits the given scenario
+     - ❌ BAD: Questions asking to count items or list multiple answers
+     - ✅ GOOD: Questions asking "which ONE region needs priority support?"
 
-  ### [Example Scenarios (Public)]
-  - Context describes eligibility criteria for a subsidy → Question asks which regions qualify
-  - Context outlines budget allocation rules → Question asks which departments receive funding
-  - Context specifies demographic thresholds → Question asks which areas need intervention
+  ### [Example Scenarios (Public) - SELECT ONE ITEM]
+  - Budget allocation: "예산 삭감 상황에서 우선적으로 유지해야 할 사업은?"
+  - Policy evaluation: "정책 효과가 가장 높은 지역에 추가 지원을 할 때, 해당 지역은?"
+  - Emergency response: "재난 상황에서 가장 먼저 지원해야 할 취약 지역은?"
+  - Resource prioritization: "인력이 부족할 때, 가장 시급히 충원해야 할 부서는?"
 
   ### [Output Format (JSON)]
   {{
     "qa_pairs": [
       {{
-        "question": "Question requiring context to answer",
-        "answer": "Answer derived from table + context",
+        "question": "(MINIMUM 500자) 예시: 지방자치단체는 올해 예산 편성 과정에서 전년 대비 10% 삭감된 복지예산을 효율적으로 배분해야 하는 상황에 직면하였다. 기획재정담당관은 기존 사업의 성과평가 결과를 바탕으로 효과성이 입증된 사업에 우선 배정해야 한다고 보고하였다. 또한 주민복지팀장은 취약계층 지원 사업의 경우 법적 의무사항이 있어 일정 수준 이상의 예산 확보가 필수적이라고 강조하였다. 내부 기준에 따르면 전년도 집행률 90% 이상이면서 수혜자 만족도가 4.0 이상인 사업이 우선 지원 대상이다. 현재 복지사업 현황표에서 해당 기준을 모두 충족하는 사업을 찾아 답하시오.",
+        "answer": "해당 사업명 (max 50 chars)",
         "type": "long_sequence",
-        "reasoning_annotation": "Step 1: Extract key criteria from context. Step 2: Apply criteria to table. Step 3: Derive answer.",
-        "context": "정책 지침에 따르면... (2-4 sentences of policy context in Korean)"
+        "reasoning_annotation": "Step 1: Identify budget allocation criteria from scenario (execution rate >= 90%, satisfaction >= 4.0). Step 2: Filter programs meeting execution rate criterion. Step 3: Check satisfaction score among filtered programs. Step 4: Select the ONE program meeting all criteria.",
+        "context": null
       }}
     ]
   }}

--- a/run_all.sh
+++ b/run_all.sh
@@ -42,7 +42,7 @@ INPUT_JSON=""
 DOMAIN=""
 OUTPUT_DIR=""
 PROVIDER="claude"
-MODEL="claude-sonnet-4-5"
+MODEL="claude-haiku-4-5"
 VLLM_URL="http://localhost:8000/v1"
 
 # Pipeline steps (default: generate + capture)

--- a/run_pipeline_json.py
+++ b/run_pipeline_json.py
@@ -298,6 +298,7 @@ def process_single_pair(
     config_path: str,
     arg_domain: str,
     qa_only: bool,
+    skip_qa: bool,
     notion_uploader: Any,
     randomize_style: bool = True
 ) -> Dict:
@@ -423,20 +424,24 @@ def process_single_pair(
             
             pair_tables = temp_tables
 
-            # 2. Generate QA for the Pair
-            print(f"  [Pair {index+1}] Generating QA for pair...")
-            qa_state = run_synthetic_table_flow(
-                image_path=str(paths[0]),
-                image_paths=image_paths_str,
-                provider=provider,
-                model=model,
-                config_path=config_path,
-                qa_only=True,  # Focus on QA from these images
-                domain=domain
-            )
-                
-            if qa_state.get("qa_results"):
-                pair_qa = qa_state["qa_results"]
+            # 2. Generate QA for the Pair (unless skip_qa is set)
+            if skip_qa:
+                print(f"  [Pair {index+1}] Skipping QA generation (--skip-qa)")
+                pair_qa = []
+            else:
+                print(f"  [Pair {index+1}] Generating QA for pair...")
+                qa_state = run_synthetic_table_flow(
+                    image_path=str(paths[0]),
+                    image_paths=image_paths_str,
+                    provider=provider,
+                    model=model,
+                    config_path=config_path,
+                    qa_only=True,  # Focus on QA from these images
+                    domain=domain
+                )
+
+                if qa_state.get("qa_results"):
+                    pair_qa = qa_state["qa_results"]
 
         # Create structured result with keys
         result_item = {
@@ -493,6 +498,7 @@ def run_pipeline(
     config_path: str = "apis/gemini_keys.yaml",
     arg_domain: str = None,
     qa_only: bool = False,
+    skip_qa: bool = False,
     upload_to_notion: bool = False,
     max_workers: int = 3,
     randomize_style: bool = True
@@ -529,6 +535,7 @@ def run_pipeline(
                 config_path,
                 arg_domain,
                 qa_only,
+                skip_qa,
                 notion_uploader,
                 randomize_style
             ): i for i, item in enumerate(json_input)
@@ -572,6 +579,7 @@ def main():
     parser.add_argument("--config-path", default="apis/gemini_keys.yaml", help="Path to gemini_keys.yaml")
     parser.add_argument("--domain", help="Force specific domain")
     parser.add_argument("--qa-only", action="store_true", help="Skip table generation, only generate QA (applies to all domains)")
+    parser.add_argument("--skip-qa", action="store_true", help="Skip QA generation, only generate tables")
     parser.add_argument("--upload-to-notion", action="store_true", help="Upload QA results to Notion database")
     parser.add_argument("--max-workers", type=int, default=3, help="Maximum number of parallel workers (default: 3)")
     parser.add_argument("--randomize-style", action="store_true", default=True, help="Randomize HTML table styles (fonts, colors) for diversity (default: True)")
@@ -614,6 +622,7 @@ def main():
         config_path=args.config_path,
         arg_domain=args.domain,
         qa_only=args.qa_only,
+        skip_qa=args.skip_qa,
         upload_to_notion=args.upload_to_notion,
         max_workers=args.max_workers,
         randomize_style=args.randomize_style

--- a/scripts/regenerate_input_json.py
+++ b/scripts/regenerate_input_json.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Regenerate single_table_{domain}_input.json from actual files in data/{Domain}/Table/
+"""
+
+import json
+import re
+from pathlib import Path
+from typing import Optional
+
+# Domain configurations
+DOMAIN_CONFIG = {
+    "finance": {"prefix": "F", "folder": "Finance"},
+    "business": {"prefix": "B", "folder": "Business"},
+    "academic": {"prefix": "A", "folder": "Academic"},
+    "medical": {"prefix": "M", "folder": "Medical"},
+    "public": {"prefix": "P", "folder": "Public"},
+    "insurance": {"prefix": "I", "folder": "Insurance"},
+}
+
+
+def natural_sort_key(s: str):
+    """Sort strings with numbers naturally (e.g., F_origin_2 before F_origin_10)"""
+    return [int(text) if text.isdigit() else text.lower()
+            for text in re.split(r'(\d+)', str(s))]
+
+
+def regenerate_input_json(
+    domain: str,
+    data_root: Path,
+    output_path: Path,
+    dry_run: bool = False
+) -> int:
+    """
+    Scan data/{Domain}/Table/ and regenerate input JSON.
+
+    Returns:
+        Number of entries generated
+    """
+    config = DOMAIN_CONFIG.get(domain.lower())
+    if not config:
+        raise ValueError(f"Unknown domain: {domain}. Available: {list(DOMAIN_CONFIG.keys())}")
+
+    prefix = config["prefix"]
+    folder = config["folder"]
+    table_dir = data_root / folder / "Table"
+
+    if not table_dir.exists():
+        raise FileNotFoundError(f"Table directory not found: {table_dir}")
+
+    # Collect all PNG files
+    entries = []
+
+    # Get all origin directories
+    origin_dirs = sorted(
+        [d for d in table_dir.iterdir() if d.is_dir()],
+        key=lambda x: natural_sort_key(x.name)
+    )
+
+    for origin_dir in origin_dirs:
+        origin = origin_dir.name
+
+        # Get all PNG files in this origin directory
+        png_files = sorted(
+            origin_dir.glob("*.png"),
+            key=lambda x: natural_sort_key(x.name)
+        )
+
+        for png_file in png_files:
+            table_id = png_file.stem  # filename without extension
+
+            # Build relative path from project root
+            rel_path = f"data/{folder}/Table/{origin}/{png_file.name}"
+
+            entry = {
+                "index": len(entries),
+                "pair_id": f"{origin}_{table_id}",
+                "image_paths": [rel_path],
+                "domain": folder,
+                "origin": origin,
+                "table_id": table_id
+            }
+            entries.append(entry)
+
+    if dry_run:
+        print(f"[DRY RUN] Would generate {len(entries)} entries")
+        print(f"[DRY RUN] Output path: {output_path}")
+        print(f"\nFirst 5 entries:")
+        for entry in entries[:5]:
+            print(f"  - {entry['pair_id']}: {entry['image_paths'][0]}")
+        if len(entries) > 5:
+            print(f"  ... and {len(entries) - 5} more")
+        return len(entries)
+
+    # Write JSON
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, 'w', encoding='utf-8') as f:
+        json.dump(entries, f, indent=2, ensure_ascii=False)
+
+    print(f"Generated {len(entries)} entries -> {output_path}")
+    return len(entries)
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Regenerate single table input JSON from actual files")
+    parser.add_argument("--domain", "-d", required=True,
+                       choices=list(DOMAIN_CONFIG.keys()),
+                       help="Domain to regenerate")
+    parser.add_argument("--data-root", "-r", type=Path, default=Path("data"),
+                       help="Data root directory (default: data)")
+    parser.add_argument("--output", "-o", type=Path, default=None,
+                       help="Output JSON path (default: single_image_json_list/single_table_{domain}_input.json)")
+    parser.add_argument("--dry-run", action="store_true",
+                       help="Show what would be generated without writing")
+    parser.add_argument("--all", action="store_true",
+                       help="Regenerate all domains")
+
+    args = parser.parse_args()
+
+    # Find project root (where data/ and single_image_json_list/ are)
+    script_dir = Path(__file__).parent
+    project_root = script_dir.parent
+    data_root = project_root / args.data_root
+
+    if args.all:
+        domains = list(DOMAIN_CONFIG.keys())
+    else:
+        domains = [args.domain]
+
+    total = 0
+    for domain in domains:
+        config = DOMAIN_CONFIG[domain]
+
+        if args.output and len(domains) == 1:
+            output_path = args.output
+        else:
+            output_path = project_root / "single_image_json_list" / f"single_table_{domain}_input.json"
+
+        try:
+            count = regenerate_input_json(
+                domain=domain,
+                data_root=data_root,
+                output_path=output_path,
+                dry_run=args.dry_run
+            )
+            total += count
+        except FileNotFoundError as e:
+            print(f"[SKIP] {domain}: {e}")
+
+    print(f"\nTotal: {total} entries")
+
+
+if __name__ == "__main__":
+    main()

--- a/single_image_json_list/single_table_finance_input.json
+++ b/single_image_json_list/single_table_finance_input.json
@@ -121,646 +121,6 @@
   },
   {
     "index": 12,
-    "pair_id": "F_origin_10_F_table_14_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_10/F_table_14_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_10",
-    "table_id": "F_table_14_0"
-  },
-  {
-    "index": 13,
-    "pair_id": "F_origin_10_F_table_14_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_10/F_table_14_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_10",
-    "table_id": "F_table_14_1"
-  },
-  {
-    "index": 14,
-    "pair_id": "F_origin_10_F_table_14_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_10/F_table_14_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_10",
-    "table_id": "F_table_14_2"
-  },
-  {
-    "index": 15,
-    "pair_id": "F_origin_10_F_table_14_3",
-    "image_paths": [
-      "data/Finance/Table/F_origin_10/F_table_14_3.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_10",
-    "table_id": "F_table_14_3"
-  },
-  {
-    "index": 16,
-    "pair_id": "F_origin_10_F_table_14_4",
-    "image_paths": [
-      "data/Finance/Table/F_origin_10/F_table_14_4.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_10",
-    "table_id": "F_table_14_4"
-  },
-  {
-    "index": 17,
-    "pair_id": "F_origin_11_F_table_15_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_11/F_table_15_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_11",
-    "table_id": "F_table_15_0"
-  },
-  {
-    "index": 18,
-    "pair_id": "F_origin_11_F_table_15_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_11/F_table_15_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_11",
-    "table_id": "F_table_15_1"
-  },
-  {
-    "index": 19,
-    "pair_id": "F_origin_11_F_table_15_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_11/F_table_15_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_11",
-    "table_id": "F_table_15_2"
-  },
-  {
-    "index": 20,
-    "pair_id": "F_origin_11_F_table_15_3",
-    "image_paths": [
-      "data/Finance/Table/F_origin_11/F_table_15_3.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_11",
-    "table_id": "F_table_15_3"
-  },
-  {
-    "index": 21,
-    "pair_id": "F_origin_11_F_table_15_4",
-    "image_paths": [
-      "data/Finance/Table/F_origin_11/F_table_15_4.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_11",
-    "table_id": "F_table_15_4"
-  },
-  {
-    "index": 22,
-    "pair_id": "F_origin_11_F_table_15_5",
-    "image_paths": [
-      "data/Finance/Table/F_origin_11/F_table_15_5.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_11",
-    "table_id": "F_table_15_5"
-  },
-  {
-    "index": 23,
-    "pair_id": "F_origin_12_F_table_16_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_12/F_table_16_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_12",
-    "table_id": "F_table_16_0"
-  },
-  {
-    "index": 24,
-    "pair_id": "F_origin_12_F_table_17_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_12/F_table_17_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_12",
-    "table_id": "F_table_17_0"
-  },
-  {
-    "index": 25,
-    "pair_id": "F_origin_12_F_table_18_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_12/F_table_18_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_12",
-    "table_id": "F_table_18_0"
-  },
-  {
-    "index": 26,
-    "pair_id": "F_origin_12_F_table_19_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_12/F_table_19_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_12",
-    "table_id": "F_table_19_0"
-  },
-  {
-    "index": 27,
-    "pair_id": "F_origin_12_F_table_20_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_12/F_table_20_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_12",
-    "table_id": "F_table_20_0"
-  },
-  {
-    "index": 28,
-    "pair_id": "F_origin_12_F_table_21_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_12/F_table_21_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_12",
-    "table_id": "F_table_21_0"
-  },
-  {
-    "index": 29,
-    "pair_id": "F_origin_13_F_table_21_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_13/F_table_21_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_13",
-    "table_id": "F_table_21_0"
-  },
-  {
-    "index": 30,
-    "pair_id": "F_origin_13_F_table_22_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_13/F_table_22_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_13",
-    "table_id": "F_table_22_0"
-  },
-  {
-    "index": 31,
-    "pair_id": "F_origin_13_F_table_23_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_13/F_table_23_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_13",
-    "table_id": "F_table_23_0"
-  },
-  {
-    "index": 32,
-    "pair_id": "F_origin_13_F_table_24_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_13/F_table_24_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_13",
-    "table_id": "F_table_24_0"
-  },
-  {
-    "index": 33,
-    "pair_id": "F_origin_13_F_table_25_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_13/F_table_25_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_13",
-    "table_id": "F_table_25_0"
-  },
-  {
-    "index": 34,
-    "pair_id": "F_origin_14_F_table_26_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_14/F_table_26_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_14",
-    "table_id": "F_table_26_0"
-  },
-  {
-    "index": 35,
-    "pair_id": "F_origin_14_F_table_27_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_14/F_table_27_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_14",
-    "table_id": "F_table_27_0"
-  },
-  {
-    "index": 36,
-    "pair_id": "F_origin_14_F_table_28_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_14/F_table_28_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_14",
-    "table_id": "F_table_28_0"
-  },
-  {
-    "index": 37,
-    "pair_id": "F_origin_14_F_table_29_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_14/F_table_29_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_14",
-    "table_id": "F_table_29_0"
-  },
-  {
-    "index": 38,
-    "pair_id": "F_origin_14_F_table_30_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_14/F_table_30_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_14",
-    "table_id": "F_table_30_0"
-  },
-  {
-    "index": 39,
-    "pair_id": "F_origin_14_F_table_31_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_14/F_table_31_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_14",
-    "table_id": "F_table_31_0"
-  },
-  {
-    "index": 40,
-    "pair_id": "F_origin_15_F_table_32_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_15/F_table_32_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_15",
-    "table_id": "F_table_32_0"
-  },
-  {
-    "index": 41,
-    "pair_id": "F_origin_15_F_table_33_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_15/F_table_33_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_15",
-    "table_id": "F_table_33_0"
-  },
-  {
-    "index": 42,
-    "pair_id": "F_origin_15_F_table_34_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_15/F_table_34_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_15",
-    "table_id": "F_table_34_0"
-  },
-  {
-    "index": 43,
-    "pair_id": "F_origin_15_F_table_35_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_15/F_table_35_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_15",
-    "table_id": "F_table_35_0"
-  },
-  {
-    "index": 44,
-    "pair_id": "F_origin_15_F_table_36_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_15/F_table_36_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_15",
-    "table_id": "F_table_36_0"
-  },
-  {
-    "index": 45,
-    "pair_id": "F_origin_16_F_table_37_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_16/F_table_37_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_16",
-    "table_id": "F_table_37_0"
-  },
-  {
-    "index": 46,
-    "pair_id": "F_origin_16_F_table_38_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_16/F_table_38_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_16",
-    "table_id": "F_table_38_0"
-  },
-  {
-    "index": 47,
-    "pair_id": "F_origin_16_F_table_39_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_16/F_table_39_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_16",
-    "table_id": "F_table_39_0"
-  },
-  {
-    "index": 48,
-    "pair_id": "F_origin_16_F_table_40_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_16/F_table_40_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_16",
-    "table_id": "F_table_40_0"
-  },
-  {
-    "index": 49,
-    "pair_id": "F_origin_16_F_table_41_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_16/F_table_41_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_16",
-    "table_id": "F_table_41_0"
-  },
-  {
-    "index": 50,
-    "pair_id": "F_origin_16_F_table_42_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_16/F_table_42_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_16",
-    "table_id": "F_table_42_0"
-  },
-  {
-    "index": 51,
-    "pair_id": "F_origin_16_F_table_43_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_16/F_table_43_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_16",
-    "table_id": "F_table_43_0"
-  },
-  {
-    "index": 52,
-    "pair_id": "F_origin_16_F_table_44_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_16/F_table_44_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_16",
-    "table_id": "F_table_44_0"
-  },
-  {
-    "index": 53,
-    "pair_id": "F_origin_16_F_table_45_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_16/F_table_45_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_16",
-    "table_id": "F_table_45_0"
-  },
-  {
-    "index": 54,
-    "pair_id": "F_origin_17_F_table_46_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_17/F_table_46_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_17",
-    "table_id": "F_table_46_0"
-  },
-  {
-    "index": 55,
-    "pair_id": "F_origin_17_F_table_47_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_17/F_table_47_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_17",
-    "table_id": "F_table_47_0"
-  },
-  {
-    "index": 56,
-    "pair_id": "F_origin_17_F_table_48_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_17/F_table_48_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_17",
-    "table_id": "F_table_48_0"
-  },
-  {
-    "index": 57,
-    "pair_id": "F_origin_17_F_table_49_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_17/F_table_49_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_17",
-    "table_id": "F_table_49_0"
-  },
-  {
-    "index": 58,
-    "pair_id": "F_origin_17_F_table_50_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_17/F_table_50_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_17",
-    "table_id": "F_table_50_0"
-  },
-  {
-    "index": 59,
-    "pair_id": "F_origin_17_F_table_51_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_17/F_table_51_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_17",
-    "table_id": "F_table_51_0"
-  },
-  {
-    "index": 60,
-    "pair_id": "F_origin_17_F_table_52_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_17/F_table_52_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_17",
-    "table_id": "F_table_52_0"
-  },
-  {
-    "index": 61,
-    "pair_id": "F_origin_17_F_table_53_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_17/F_table_53_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_17",
-    "table_id": "F_table_53_0"
-  },
-  {
-    "index": 62,
-    "pair_id": "F_origin_17_F_table_54_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_17/F_table_54_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_17",
-    "table_id": "F_table_54_0"
-  },
-  {
-    "index": 63,
-    "pair_id": "F_origin_18_F_table_55_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_18/F_table_55_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_18",
-    "table_id": "F_table_55_0"
-  },
-  {
-    "index": 64,
-    "pair_id": "F_origin_18_F_table_56_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_18/F_table_56_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_18",
-    "table_id": "F_table_56_0"
-  },
-  {
-    "index": 65,
-    "pair_id": "F_origin_18_F_table_57_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_18/F_table_57_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_18",
-    "table_id": "F_table_57_0"
-  },
-  {
-    "index": 66,
-    "pair_id": "F_origin_18_F_table_58_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_18/F_table_58_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_18",
-    "table_id": "F_table_58_0"
-  },
-  {
-    "index": 67,
-    "pair_id": "F_origin_19_F_table_59_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_19/F_table_59_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_19",
-    "table_id": "F_table_59_0"
-  },
-  {
-    "index": 68,
-    "pair_id": "F_origin_19_F_table_59_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_19/F_table_59_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_19",
-    "table_id": "F_table_59_1"
-  },
-  {
-    "index": 69,
-    "pair_id": "F_origin_19_F_table_60_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_19/F_table_60_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_19",
-    "table_id": "F_table_60_0"
-  },
-  {
-    "index": 70,
-    "pair_id": "F_origin_19_F_table_61_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_19/F_table_61_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_19",
-    "table_id": "F_table_61_0"
-  },
-  {
-    "index": 71,
-    "pair_id": "F_origin_19_F_table_62_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_19/F_table_62_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_19",
-    "table_id": "F_table_62_0"
-  },
-  {
-    "index": 72,
-    "pair_id": "F_origin_19_F_table_63_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_19/F_table_63_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_19",
-    "table_id": "F_table_63_0"
-  },
-  {
-    "index": 73,
-    "pair_id": "F_origin_19_F_table_64_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_19/F_table_64_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_19",
-    "table_id": "F_table_64_0"
-  },
-  {
-    "index": 74,
-    "pair_id": "F_origin_19_F_table_65_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_19/F_table_65_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_19",
-    "table_id": "F_table_65_0"
-  },
-  {
-    "index": 75,
-    "pair_id": "F_origin_19_F_table_66_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_19/F_table_66_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_19",
-    "table_id": "F_table_66_0"
-  },
-  {
-    "index": 76,
     "pair_id": "F_origin_2_F_table_3_0",
     "image_paths": [
       "data/Finance/Table/F_origin_2/F_table_3_0.png"
@@ -770,7 +130,7 @@
     "table_id": "F_table_3_0"
   },
   {
-    "index": 77,
+    "index": 13,
     "pair_id": "F_origin_2_F_table_3_1",
     "image_paths": [
       "data/Finance/Table/F_origin_2/F_table_3_1.png"
@@ -780,7 +140,7 @@
     "table_id": "F_table_3_1"
   },
   {
-    "index": 78,
+    "index": 14,
     "pair_id": "F_origin_2_F_table_3_2",
     "image_paths": [
       "data/Finance/Table/F_origin_2/F_table_3_2.png"
@@ -790,7 +150,7 @@
     "table_id": "F_table_3_2"
   },
   {
-    "index": 79,
+    "index": 15,
     "pair_id": "F_origin_2_F_table_3_3",
     "image_paths": [
       "data/Finance/Table/F_origin_2/F_table_3_3.png"
@@ -800,7 +160,7 @@
     "table_id": "F_table_3_3"
   },
   {
-    "index": 80,
+    "index": 16,
     "pair_id": "F_origin_2_F_table_3_4",
     "image_paths": [
       "data/Finance/Table/F_origin_2/F_table_3_4.png"
@@ -810,7 +170,7 @@
     "table_id": "F_table_3_4"
   },
   {
-    "index": 81,
+    "index": 17,
     "pair_id": "F_origin_2_F_table_3_5",
     "image_paths": [
       "data/Finance/Table/F_origin_2/F_table_3_5.png"
@@ -820,7 +180,7 @@
     "table_id": "F_table_3_5"
   },
   {
-    "index": 82,
+    "index": 18,
     "pair_id": "F_origin_2_F_table_4_0",
     "image_paths": [
       "data/Finance/Table/F_origin_2/F_table_4_0.png"
@@ -830,7 +190,7 @@
     "table_id": "F_table_4_0"
   },
   {
-    "index": 83,
+    "index": 19,
     "pair_id": "F_origin_2_F_table_4_1",
     "image_paths": [
       "data/Finance/Table/F_origin_2/F_table_4_1.png"
@@ -840,727 +200,7 @@
     "table_id": "F_table_4_1"
   },
   {
-    "index": 84,
-    "pair_id": "F_origin_20_F_table_67_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_20/F_table_67_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_20",
-    "table_id": "F_table_67_0"
-  },
-  {
-    "index": 85,
-    "pair_id": "F_origin_20_F_table_67_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_20/F_table_67_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_20",
-    "table_id": "F_table_67_1"
-  },
-  {
-    "index": 86,
-    "pair_id": "F_origin_20_F_table_68_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_20/F_table_68_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_20",
-    "table_id": "F_table_68_0"
-  },
-  {
-    "index": 87,
-    "pair_id": "F_origin_20_F_table_68_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_20/F_table_68_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_20",
-    "table_id": "F_table_68_1"
-  },
-  {
-    "index": 88,
-    "pair_id": "F_origin_20_F_table_68_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_20/F_table_68_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_20",
-    "table_id": "F_table_68_2"
-  },
-  {
-    "index": 89,
-    "pair_id": "F_origin_20_F_table_68_3",
-    "image_paths": [
-      "data/Finance/Table/F_origin_20/F_table_68_3.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_20",
-    "table_id": "F_table_68_3"
-  },
-  {
-    "index": 90,
-    "pair_id": "F_origin_20_F_table_68_4",
-    "image_paths": [
-      "data/Finance/Table/F_origin_20/F_table_68_4.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_20",
-    "table_id": "F_table_68_4"
-  },
-  {
-    "index": 91,
-    "pair_id": "F_origin_20_F_table_68_5",
-    "image_paths": [
-      "data/Finance/Table/F_origin_20/F_table_68_5.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_20",
-    "table_id": "F_table_68_5"
-  },
-  {
-    "index": 92,
-    "pair_id": "F_origin_20_F_table_68_6",
-    "image_paths": [
-      "data/Finance/Table/F_origin_20/F_table_68_6.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_20",
-    "table_id": "F_table_68_6"
-  },
-  {
-    "index": 93,
-    "pair_id": "F_origin_20_F_table_69_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_20/F_table_69_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_20",
-    "table_id": "F_table_69_0"
-  },
-  {
-    "index": 94,
-    "pair_id": "F_origin_21_F_table_70_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_21/F_table_70_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_21",
-    "table_id": "F_table_70_0"
-  },
-  {
-    "index": 95,
-    "pair_id": "F_origin_21_F_table_70_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_21/F_table_70_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_21",
-    "table_id": "F_table_70_1"
-  },
-  {
-    "index": 96,
-    "pair_id": "F_origin_21_F_table_70_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_21/F_table_70_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_21",
-    "table_id": "F_table_70_2"
-  },
-  {
-    "index": 97,
-    "pair_id": "F_origin_21_F_table_70_3",
-    "image_paths": [
-      "data/Finance/Table/F_origin_21/F_table_70_3.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_21",
-    "table_id": "F_table_70_3"
-  },
-  {
-    "index": 98,
-    "pair_id": "F_origin_21_F_table_71_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_21/F_table_71_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_21",
-    "table_id": "F_table_71_0"
-  },
-  {
-    "index": 99,
-    "pair_id": "F_origin_22_F_table_72_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_22/F_table_72_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_22",
-    "table_id": "F_table_72_0"
-  },
-  {
-    "index": 100,
-    "pair_id": "F_origin_22_F_table_72_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_22/F_table_72_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_22",
-    "table_id": "F_table_72_1"
-  },
-  {
-    "index": 101,
-    "pair_id": "F_origin_22_F_table_72_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_22/F_table_72_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_22",
-    "table_id": "F_table_72_2"
-  },
-  {
-    "index": 102,
-    "pair_id": "F_origin_22_F_table_72_3",
-    "image_paths": [
-      "data/Finance/Table/F_origin_22/F_table_72_3.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_22",
-    "table_id": "F_table_72_3"
-  },
-  {
-    "index": 103,
-    "pair_id": "F_origin_22_F_table_72_4",
-    "image_paths": [
-      "data/Finance/Table/F_origin_22/F_table_72_4.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_22",
-    "table_id": "F_table_72_4"
-  },
-  {
-    "index": 104,
-    "pair_id": "F_origin_22_F_table_72_5",
-    "image_paths": [
-      "data/Finance/Table/F_origin_22/F_table_72_5.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_22",
-    "table_id": "F_table_72_5"
-  },
-  {
-    "index": 105,
-    "pair_id": "F_origin_22_F_table_73_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_22/F_table_73_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_22",
-    "table_id": "F_table_73_0"
-  },
-  {
-    "index": 106,
-    "pair_id": "F_origin_23_F_table_74_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_23/F_table_74_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_23",
-    "table_id": "F_table_74_0"
-  },
-  {
-    "index": 107,
-    "pair_id": "F_origin_23_F_table_74_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_23/F_table_74_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_23",
-    "table_id": "F_table_74_1"
-  },
-  {
-    "index": 108,
-    "pair_id": "F_origin_23_F_table_74_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_23/F_table_74_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_23",
-    "table_id": "F_table_74_2"
-  },
-  {
-    "index": 109,
-    "pair_id": "F_origin_23_F_table_74_3",
-    "image_paths": [
-      "data/Finance/Table/F_origin_23/F_table_74_3.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_23",
-    "table_id": "F_table_74_3"
-  },
-  {
-    "index": 110,
-    "pair_id": "F_origin_23_F_table_74_4",
-    "image_paths": [
-      "data/Finance/Table/F_origin_23/F_table_74_4.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_23",
-    "table_id": "F_table_74_4"
-  },
-  {
-    "index": 111,
-    "pair_id": "F_origin_23_F_table_74_5",
-    "image_paths": [
-      "data/Finance/Table/F_origin_23/F_table_74_5.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_23",
-    "table_id": "F_table_74_5"
-  },
-  {
-    "index": 112,
-    "pair_id": "F_origin_23_F_table_75_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_23/F_table_75_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_23",
-    "table_id": "F_table_75_0"
-  },
-  {
-    "index": 113,
-    "pair_id": "F_origin_24_F_table_75_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_24/F_table_75_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_24",
-    "table_id": "F_table_75_0"
-  },
-  {
-    "index": 114,
-    "pair_id": "F_origin_24_F_table_75_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_24/F_table_75_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_24",
-    "table_id": "F_table_75_1"
-  },
-  {
-    "index": 115,
-    "pair_id": "F_origin_24_F_table_75_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_24/F_table_75_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_24",
-    "table_id": "F_table_75_2"
-  },
-  {
-    "index": 116,
-    "pair_id": "F_origin_24_F_table_75_3",
-    "image_paths": [
-      "data/Finance/Table/F_origin_24/F_table_75_3.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_24",
-    "table_id": "F_table_75_3"
-  },
-  {
-    "index": 117,
-    "pair_id": "F_origin_24_F_table_75_4",
-    "image_paths": [
-      "data/Finance/Table/F_origin_24/F_table_75_4.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_24",
-    "table_id": "F_table_75_4"
-  },
-  {
-    "index": 118,
-    "pair_id": "F_origin_24_F_table_75_5",
-    "image_paths": [
-      "data/Finance/Table/F_origin_24/F_table_75_5.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_24",
-    "table_id": "F_table_75_5"
-  },
-  {
-    "index": 119,
-    "pair_id": "F_origin_24_F_table_75_6",
-    "image_paths": [
-      "data/Finance/Table/F_origin_24/F_table_75_6.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_24",
-    "table_id": "F_table_75_6"
-  },
-  {
-    "index": 120,
-    "pair_id": "F_origin_24_F_table_75_7",
-    "image_paths": [
-      "data/Finance/Table/F_origin_24/F_table_75_7.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_24",
-    "table_id": "F_table_75_7"
-  },
-  {
-    "index": 121,
-    "pair_id": "F_origin_24_F_table_76_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_24/F_table_76_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_24",
-    "table_id": "F_table_76_0"
-  },
-  {
-    "index": 122,
-    "pair_id": "F_origin_24_F_table_76_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_24/F_table_76_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_24",
-    "table_id": "F_table_76_1"
-  },
-  {
-    "index": 123,
-    "pair_id": "F_origin_24_F_table_76_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_24/F_table_76_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_24",
-    "table_id": "F_table_76_2"
-  },
-  {
-    "index": 124,
-    "pair_id": "F_origin_24_F_table_76_3",
-    "image_paths": [
-      "data/Finance/Table/F_origin_24/F_table_76_3.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_24",
-    "table_id": "F_table_76_3"
-  },
-  {
-    "index": 125,
-    "pair_id": "F_origin_24_F_table_76_4",
-    "image_paths": [
-      "data/Finance/Table/F_origin_24/F_table_76_4.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_24",
-    "table_id": "F_table_76_4"
-  },
-  {
-    "index": 126,
-    "pair_id": "F_origin_24_F_table_77_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_24/F_table_77_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_24",
-    "table_id": "F_table_77_0"
-  },
-  {
-    "index": 127,
-    "pair_id": "F_origin_25_F_table_79_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_25/F_table_79_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_25",
-    "table_id": "F_table_79_0"
-  },
-  {
-    "index": 128,
-    "pair_id": "F_origin_25_F_table_80_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_25/F_table_80_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_25",
-    "table_id": "F_table_80_0"
-  },
-  {
-    "index": 129,
-    "pair_id": "F_origin_25_F_table_81_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_25/F_table_81_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_25",
-    "table_id": "F_table_81_0"
-  },
-  {
-    "index": 130,
-    "pair_id": "F_origin_25_F_table_82_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_25/F_table_82_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_25",
-    "table_id": "F_table_82_0"
-  },
-  {
-    "index": 131,
-    "pair_id": "F_origin_25_F_table_82_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_25/F_table_82_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_25",
-    "table_id": "F_table_82_1"
-  },
-  {
-    "index": 132,
-    "pair_id": "F_origin_25_F_table_82_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_25/F_table_82_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_25",
-    "table_id": "F_table_82_2"
-  },
-  {
-    "index": 133,
-    "pair_id": "F_origin_25_F_table_83_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_25/F_table_83_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_25",
-    "table_id": "F_table_83_0"
-  },
-  {
-    "index": 134,
-    "pair_id": "F_origin_26_F_table_84_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_26/F_table_84_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_26",
-    "table_id": "F_table_84_0"
-  },
-  {
-    "index": 135,
-    "pair_id": "F_origin_26_F_table_84_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_26/F_table_84_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_26",
-    "table_id": "F_table_84_1"
-  },
-  {
-    "index": 136,
-    "pair_id": "F_origin_26_F_table_85_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_26/F_table_85_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_26",
-    "table_id": "F_table_85_0"
-  },
-  {
-    "index": 137,
-    "pair_id": "F_origin_26_F_table_86_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_26/F_table_86_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_26",
-    "table_id": "F_table_86_0"
-  },
-  {
-    "index": 138,
-    "pair_id": "F_origin_26_F_table_87_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_26/F_table_87_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_26",
-    "table_id": "F_table_87_0"
-  },
-  {
-    "index": 139,
-    "pair_id": "F_origin_27_F_table_88_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_27/F_table_88_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_27",
-    "table_id": "F_table_88_0"
-  },
-  {
-    "index": 140,
-    "pair_id": "F_origin_27_F_table_88_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_27/F_table_88_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_27",
-    "table_id": "F_table_88_1"
-  },
-  {
-    "index": 141,
-    "pair_id": "F_origin_27_F_table_89_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_27/F_table_89_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_27",
-    "table_id": "F_table_89_0"
-  },
-  {
-    "index": 142,
-    "pair_id": "F_origin_27_F_table_89_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_27/F_table_89_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_27",
-    "table_id": "F_table_89_1"
-  },
-  {
-    "index": 143,
-    "pair_id": "F_origin_27_F_table_89_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_27/F_table_89_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_27",
-    "table_id": "F_table_89_2"
-  },
-  {
-    "index": 144,
-    "pair_id": "F_origin_27_F_table_90_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_27/F_table_90_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_27",
-    "table_id": "F_table_90_0"
-  },
-  {
-    "index": 145,
-    "pair_id": "F_origin_28_F_table_91_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_28/F_table_91_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_28",
-    "table_id": "F_table_91_0"
-  },
-  {
-    "index": 146,
-    "pair_id": "F_origin_28_F_table_91_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_28/F_table_91_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_28",
-    "table_id": "F_table_91_1"
-  },
-  {
-    "index": 147,
-    "pair_id": "F_origin_28_F_table_91_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_28/F_table_91_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_28",
-    "table_id": "F_table_91_2"
-  },
-  {
-    "index": 148,
-    "pair_id": "F_origin_28_F_table_91_3",
-    "image_paths": [
-      "data/Finance/Table/F_origin_28/F_table_91_3.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_28",
-    "table_id": "F_table_91_3"
-  },
-  {
-    "index": 149,
-    "pair_id": "F_origin_28_F_table_92_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_28/F_table_92_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_28",
-    "table_id": "F_table_92_0"
-  },
-  {
-    "index": 150,
-    "pair_id": "F_origin_29_F_table_93_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_29/F_table_93_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_29",
-    "table_id": "F_table_93_0"
-  },
-  {
-    "index": 151,
-    "pair_id": "F_origin_29_F_table_93_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_29/F_table_93_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_29",
-    "table_id": "F_table_93_1"
-  },
-  {
-    "index": 152,
-    "pair_id": "F_origin_29_F_table_93_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_29/F_table_93_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_29",
-    "table_id": "F_table_93_2"
-  },
-  {
-    "index": 153,
-    "pair_id": "F_origin_29_F_table_93_3",
-    "image_paths": [
-      "data/Finance/Table/F_origin_29/F_table_93_3.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_29",
-    "table_id": "F_table_93_3"
-  },
-  {
-    "index": 154,
-    "pair_id": "F_origin_29_F_table_93_4",
-    "image_paths": [
-      "data/Finance/Table/F_origin_29/F_table_93_4.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_29",
-    "table_id": "F_table_93_4"
-  },
-  {
-    "index": 155,
-    "pair_id": "F_origin_29_F_table_94_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_29/F_table_94_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_29",
-    "table_id": "F_table_94_0"
-  },
-  {
-    "index": 156,
+    "index": 20,
     "pair_id": "F_origin_3_F_table_5_0",
     "image_paths": [
       "data/Finance/Table/F_origin_3/F_table_5_0.png"
@@ -1570,7 +210,7 @@
     "table_id": "F_table_5_0"
   },
   {
-    "index": 157,
+    "index": 21,
     "pair_id": "F_origin_3_F_table_5_1",
     "image_paths": [
       "data/Finance/Table/F_origin_3/F_table_5_1.png"
@@ -1580,27 +220,7 @@
     "table_id": "F_table_5_1"
   },
   {
-    "index": 158,
-    "pair_id": "F_origin_3_F_table_5_10",
-    "image_paths": [
-      "data/Finance/Table/F_origin_3/F_table_5_10.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_3",
-    "table_id": "F_table_5_10"
-  },
-  {
-    "index": 159,
-    "pair_id": "F_origin_3_F_table_5_11",
-    "image_paths": [
-      "data/Finance/Table/F_origin_3/F_table_5_11.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_3",
-    "table_id": "F_table_5_11"
-  },
-  {
-    "index": 160,
+    "index": 22,
     "pair_id": "F_origin_3_F_table_5_2",
     "image_paths": [
       "data/Finance/Table/F_origin_3/F_table_5_2.png"
@@ -1610,7 +230,7 @@
     "table_id": "F_table_5_2"
   },
   {
-    "index": 161,
+    "index": 23,
     "pair_id": "F_origin_3_F_table_5_3",
     "image_paths": [
       "data/Finance/Table/F_origin_3/F_table_5_3.png"
@@ -1620,7 +240,7 @@
     "table_id": "F_table_5_3"
   },
   {
-    "index": 162,
+    "index": 24,
     "pair_id": "F_origin_3_F_table_5_4",
     "image_paths": [
       "data/Finance/Table/F_origin_3/F_table_5_4.png"
@@ -1630,7 +250,7 @@
     "table_id": "F_table_5_4"
   },
   {
-    "index": 163,
+    "index": 25,
     "pair_id": "F_origin_3_F_table_5_5",
     "image_paths": [
       "data/Finance/Table/F_origin_3/F_table_5_5.png"
@@ -1640,7 +260,7 @@
     "table_id": "F_table_5_5"
   },
   {
-    "index": 164,
+    "index": 26,
     "pair_id": "F_origin_3_F_table_5_6",
     "image_paths": [
       "data/Finance/Table/F_origin_3/F_table_5_6.png"
@@ -1650,7 +270,7 @@
     "table_id": "F_table_5_6"
   },
   {
-    "index": 165,
+    "index": 27,
     "pair_id": "F_origin_3_F_table_5_7",
     "image_paths": [
       "data/Finance/Table/F_origin_3/F_table_5_7.png"
@@ -1660,7 +280,7 @@
     "table_id": "F_table_5_7"
   },
   {
-    "index": 166,
+    "index": 28,
     "pair_id": "F_origin_3_F_table_5_8",
     "image_paths": [
       "data/Finance/Table/F_origin_3/F_table_5_8.png"
@@ -1670,7 +290,7 @@
     "table_id": "F_table_5_8"
   },
   {
-    "index": 167,
+    "index": 29,
     "pair_id": "F_origin_3_F_table_5_9",
     "image_paths": [
       "data/Finance/Table/F_origin_3/F_table_5_9.png"
@@ -1680,537 +300,27 @@
     "table_id": "F_table_5_9"
   },
   {
-    "index": 168,
-    "pair_id": "F_origin_30_F_table_95_0",
+    "index": 30,
+    "pair_id": "F_origin_3_F_table_5_10",
     "image_paths": [
-      "data/Finance/Table/F_origin_30/F_table_95_0.png"
+      "data/Finance/Table/F_origin_3/F_table_5_10.png"
     ],
     "domain": "Finance",
-    "origin": "F_origin_30",
-    "table_id": "F_table_95_0"
+    "origin": "F_origin_3",
+    "table_id": "F_table_5_10"
   },
   {
-    "index": 169,
-    "pair_id": "F_origin_30_F_table_96_0",
+    "index": 31,
+    "pair_id": "F_origin_3_F_table_5_11",
     "image_paths": [
-      "data/Finance/Table/F_origin_30/F_table_96_0.png"
+      "data/Finance/Table/F_origin_3/F_table_5_11.png"
     ],
     "domain": "Finance",
-    "origin": "F_origin_30",
-    "table_id": "F_table_96_0"
+    "origin": "F_origin_3",
+    "table_id": "F_table_5_11"
   },
   {
-    "index": 170,
-    "pair_id": "F_origin_30_F_table_97_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_30/F_table_97_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_30",
-    "table_id": "F_table_97_0"
-  },
-  {
-    "index": 171,
-    "pair_id": "F_origin_30_F_table_97_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_30/F_table_97_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_30",
-    "table_id": "F_table_97_1"
-  },
-  {
-    "index": 172,
-    "pair_id": "F_origin_30_F_table_97_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_30/F_table_97_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_30",
-    "table_id": "F_table_97_2"
-  },
-  {
-    "index": 173,
-    "pair_id": "F_origin_31_F_table_100_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_31/F_table_100_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_31",
-    "table_id": "F_table_100_0"
-  },
-  {
-    "index": 174,
-    "pair_id": "F_origin_31_F_table_100_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_31/F_table_100_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_31",
-    "table_id": "F_table_100_1"
-  },
-  {
-    "index": 175,
-    "pair_id": "F_origin_31_F_table_100_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_31/F_table_100_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_31",
-    "table_id": "F_table_100_2"
-  },
-  {
-    "index": 176,
-    "pair_id": "F_origin_31_F_table_98_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_31/F_table_98_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_31",
-    "table_id": "F_table_98_0"
-  },
-  {
-    "index": 177,
-    "pair_id": "F_origin_31_F_table_99_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_31/F_table_99_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_31",
-    "table_id": "F_table_99_0"
-  },
-  {
-    "index": 178,
-    "pair_id": "F_origin_32_F_table_101_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_32/F_table_101_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_32",
-    "table_id": "F_table_101_0"
-  },
-  {
-    "index": 179,
-    "pair_id": "F_origin_32_F_table_102_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_32/F_table_102_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_32",
-    "table_id": "F_table_102_0"
-  },
-  {
-    "index": 180,
-    "pair_id": "F_origin_32_F_table_103_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_32/F_table_103_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_32",
-    "table_id": "F_table_103_0"
-  },
-  {
-    "index": 181,
-    "pair_id": "F_origin_32_F_table_103_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_32/F_table_103_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_32",
-    "table_id": "F_table_103_1"
-  },
-  {
-    "index": 182,
-    "pair_id": "F_origin_32_F_table_103_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_32/F_table_103_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_32",
-    "table_id": "F_table_103_2"
-  },
-  {
-    "index": 183,
-    "pair_id": "F_origin_33_F_table_104_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_33/F_table_104_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_33",
-    "table_id": "F_table_104_0"
-  },
-  {
-    "index": 184,
-    "pair_id": "F_origin_33_F_table_105_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_33/F_table_105_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_33",
-    "table_id": "F_table_105_0"
-  },
-  {
-    "index": 185,
-    "pair_id": "F_origin_33_F_table_106_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_33/F_table_106_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_33",
-    "table_id": "F_table_106_0"
-  },
-  {
-    "index": 186,
-    "pair_id": "F_origin_33_F_table_106_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_33/F_table_106_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_33",
-    "table_id": "F_table_106_1"
-  },
-  {
-    "index": 187,
-    "pair_id": "F_origin_33_F_table_106_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_33/F_table_106_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_33",
-    "table_id": "F_table_106_2"
-  },
-  {
-    "index": 188,
-    "pair_id": "F_origin_34_F_table_107_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_34/F_table_107_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_34",
-    "table_id": "F_table_107_0"
-  },
-  {
-    "index": 189,
-    "pair_id": "F_origin_34_F_table_108_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_34/F_table_108_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_34",
-    "table_id": "F_table_108_0"
-  },
-  {
-    "index": 190,
-    "pair_id": "F_origin_34_F_table_109_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_34/F_table_109_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_34",
-    "table_id": "F_table_109_0"
-  },
-  {
-    "index": 191,
-    "pair_id": "F_origin_34_F_table_109_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_34/F_table_109_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_34",
-    "table_id": "F_table_109_1"
-  },
-  {
-    "index": 192,
-    "pair_id": "F_origin_34_F_table_109_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_34/F_table_109_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_34",
-    "table_id": "F_table_109_2"
-  },
-  {
-    "index": 193,
-    "pair_id": "F_origin_35_F_table_110_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_35/F_table_110_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_35",
-    "table_id": "F_table_110_0"
-  },
-  {
-    "index": 194,
-    "pair_id": "F_origin_35_F_table_111_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_35/F_table_111_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_35",
-    "table_id": "F_table_111_0"
-  },
-  {
-    "index": 195,
-    "pair_id": "F_origin_35_F_table_112_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_35/F_table_112_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_35",
-    "table_id": "F_table_112_0"
-  },
-  {
-    "index": 196,
-    "pair_id": "F_origin_35_F_table_112_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_35/F_table_112_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_35",
-    "table_id": "F_table_112_1"
-  },
-  {
-    "index": 197,
-    "pair_id": "F_origin_35_F_table_112_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_35/F_table_112_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_35",
-    "table_id": "F_table_112_2"
-  },
-  {
-    "index": 198,
-    "pair_id": "F_origin_36_F_table_113_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_36/F_table_113_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_36",
-    "table_id": "F_table_113_0"
-  },
-  {
-    "index": 199,
-    "pair_id": "F_origin_36_F_table_114_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_36/F_table_114_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_36",
-    "table_id": "F_table_114_0"
-  },
-  {
-    "index": 200,
-    "pair_id": "F_origin_36_F_table_115_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_36/F_table_115_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_36",
-    "table_id": "F_table_115_0"
-  },
-  {
-    "index": 201,
-    "pair_id": "F_origin_36_F_table_115_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_36/F_table_115_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_36",
-    "table_id": "F_table_115_1"
-  },
-  {
-    "index": 202,
-    "pair_id": "F_origin_36_F_table_115_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_36/F_table_115_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_36",
-    "table_id": "F_table_115_2"
-  },
-  {
-    "index": 203,
-    "pair_id": "F_origin_36_F_table_116_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_36/F_table_116_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_36",
-    "table_id": "F_table_116_0"
-  },
-  {
-    "index": 204,
-    "pair_id": "F_origin_37_F_table_117_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_37/F_table_117_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_37",
-    "table_id": "F_table_117_0"
-  },
-  {
-    "index": 205,
-    "pair_id": "F_origin_37_F_table_118_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_37/F_table_118_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_37",
-    "table_id": "F_table_118_0"
-  },
-  {
-    "index": 206,
-    "pair_id": "F_origin_37_F_table_119_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_37/F_table_119_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_37",
-    "table_id": "F_table_119_0"
-  },
-  {
-    "index": 207,
-    "pair_id": "F_origin_37_F_table_119_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_37/F_table_119_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_37",
-    "table_id": "F_table_119_1"
-  },
-  {
-    "index": 208,
-    "pair_id": "F_origin_37_F_table_119_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_37/F_table_119_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_37",
-    "table_id": "F_table_119_2"
-  },
-  {
-    "index": 209,
-    "pair_id": "F_origin_37_F_table_119_3",
-    "image_paths": [
-      "data/Finance/Table/F_origin_37/F_table_119_3.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_37",
-    "table_id": "F_table_119_3"
-  },
-  {
-    "index": 210,
-    "pair_id": "F_origin_37_F_table_119_4",
-    "image_paths": [
-      "data/Finance/Table/F_origin_37/F_table_119_4.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_37",
-    "table_id": "F_table_119_4"
-  },
-  {
-    "index": 211,
-    "pair_id": "F_origin_38_F_table_120_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_38/F_table_120_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_38",
-    "table_id": "F_table_120_0"
-  },
-  {
-    "index": 212,
-    "pair_id": "F_origin_38_F_table_121_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_38/F_table_121_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_38",
-    "table_id": "F_table_121_0"
-  },
-  {
-    "index": 213,
-    "pair_id": "F_origin_38_F_table_122_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_38/F_table_122_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_38",
-    "table_id": "F_table_122_0"
-  },
-  {
-    "index": 214,
-    "pair_id": "F_origin_38_F_table_122_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_38/F_table_122_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_38",
-    "table_id": "F_table_122_1"
-  },
-  {
-    "index": 215,
-    "pair_id": "F_origin_38_F_table_122_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_38/F_table_122_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_38",
-    "table_id": "F_table_122_2"
-  },
-  {
-    "index": 216,
-    "pair_id": "F_origin_39_F_table_123_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_39/F_table_123_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_39",
-    "table_id": "F_table_123_0"
-  },
-  {
-    "index": 217,
-    "pair_id": "F_origin_39_F_table_124_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_39/F_table_124_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_39",
-    "table_id": "F_table_124_0"
-  },
-  {
-    "index": 218,
-    "pair_id": "F_origin_39_F_table_125_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_39/F_table_125_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_39",
-    "table_id": "F_table_125_0"
-  },
-  {
-    "index": 219,
-    "pair_id": "F_origin_39_F_table_125_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_39/F_table_125_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_39",
-    "table_id": "F_table_125_1"
-  },
-  {
-    "index": 220,
-    "pair_id": "F_origin_39_F_table_125_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_39/F_table_125_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_39",
-    "table_id": "F_table_125_2"
-  },
-  {
-    "index": 221,
+    "index": 32,
     "pair_id": "F_origin_4_F_table_6_0",
     "image_paths": [
       "data/Finance/Table/F_origin_4/F_table_6_0.png"
@@ -2220,7 +330,7 @@
     "table_id": "F_table_6_0"
   },
   {
-    "index": 222,
+    "index": 33,
     "pair_id": "F_origin_4_F_table_6_1",
     "image_paths": [
       "data/Finance/Table/F_origin_4/F_table_6_1.png"
@@ -2230,7 +340,7 @@
     "table_id": "F_table_6_1"
   },
   {
-    "index": 223,
+    "index": 34,
     "pair_id": "F_origin_4_F_table_6_2",
     "image_paths": [
       "data/Finance/Table/F_origin_4/F_table_6_2.png"
@@ -2240,7 +350,7 @@
     "table_id": "F_table_6_2"
   },
   {
-    "index": 224,
+    "index": 35,
     "pair_id": "F_origin_4_F_table_6_3",
     "image_paths": [
       "data/Finance/Table/F_origin_4/F_table_6_3.png"
@@ -2250,617 +360,7 @@
     "table_id": "F_table_6_3"
   },
   {
-    "index": 225,
-    "pair_id": "F_origin_40_F_table_126_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_40/F_table_126_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_40",
-    "table_id": "F_table_126_0"
-  },
-  {
-    "index": 226,
-    "pair_id": "F_origin_40_F_table_127_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_40/F_table_127_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_40",
-    "table_id": "F_table_127_0"
-  },
-  {
-    "index": 227,
-    "pair_id": "F_origin_40_F_table_128_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_40/F_table_128_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_40",
-    "table_id": "F_table_128_0"
-  },
-  {
-    "index": 228,
-    "pair_id": "F_origin_40_F_table_128_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_40/F_table_128_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_40",
-    "table_id": "F_table_128_1"
-  },
-  {
-    "index": 229,
-    "pair_id": "F_origin_40_F_table_128_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_40/F_table_128_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_40",
-    "table_id": "F_table_128_2"
-  },
-  {
-    "index": 230,
-    "pair_id": "F_origin_41_F_table_129_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_41/F_table_129_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_41",
-    "table_id": "F_table_129_0"
-  },
-  {
-    "index": 231,
-    "pair_id": "F_origin_41_F_table_129_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_41/F_table_129_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_41",
-    "table_id": "F_table_129_1"
-  },
-  {
-    "index": 232,
-    "pair_id": "F_origin_41_F_table_129_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_41/F_table_129_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_41",
-    "table_id": "F_table_129_2"
-  },
-  {
-    "index": 233,
-    "pair_id": "F_origin_41_F_table_129_3",
-    "image_paths": [
-      "data/Finance/Table/F_origin_41/F_table_129_3.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_41",
-    "table_id": "F_table_129_3"
-  },
-  {
-    "index": 234,
-    "pair_id": "F_origin_41_F_table_129_4",
-    "image_paths": [
-      "data/Finance/Table/F_origin_41/F_table_129_4.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_41",
-    "table_id": "F_table_129_4"
-  },
-  {
-    "index": 235,
-    "pair_id": "F_origin_41_F_table_129_5",
-    "image_paths": [
-      "data/Finance/Table/F_origin_41/F_table_129_5.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_41",
-    "table_id": "F_table_129_5"
-  },
-  {
-    "index": 236,
-    "pair_id": "F_origin_42_F_table_130_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_42/F_table_130_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_42",
-    "table_id": "F_table_130_0"
-  },
-  {
-    "index": 237,
-    "pair_id": "F_origin_42_F_table_130_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_42/F_table_130_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_42",
-    "table_id": "F_table_130_1"
-  },
-  {
-    "index": 238,
-    "pair_id": "F_origin_42_F_table_130_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_42/F_table_130_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_42",
-    "table_id": "F_table_130_2"
-  },
-  {
-    "index": 239,
-    "pair_id": "F_origin_42_F_table_130_3",
-    "image_paths": [
-      "data/Finance/Table/F_origin_42/F_table_130_3.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_42",
-    "table_id": "F_table_130_3"
-  },
-  {
-    "index": 240,
-    "pair_id": "F_origin_42_F_table_130_4",
-    "image_paths": [
-      "data/Finance/Table/F_origin_42/F_table_130_4.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_42",
-    "table_id": "F_table_130_4"
-  },
-  {
-    "index": 241,
-    "pair_id": "F_origin_42_F_table_130_5",
-    "image_paths": [
-      "data/Finance/Table/F_origin_42/F_table_130_5.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_42",
-    "table_id": "F_table_130_5"
-  },
-  {
-    "index": 242,
-    "pair_id": "F_origin_43_F_table_131_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_43/F_table_131_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_43",
-    "table_id": "F_table_131_0"
-  },
-  {
-    "index": 243,
-    "pair_id": "F_origin_43_F_table_131_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_43/F_table_131_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_43",
-    "table_id": "F_table_131_1"
-  },
-  {
-    "index": 244,
-    "pair_id": "F_origin_43_F_table_131_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_43/F_table_131_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_43",
-    "table_id": "F_table_131_2"
-  },
-  {
-    "index": 245,
-    "pair_id": "F_origin_43_F_table_131_3",
-    "image_paths": [
-      "data/Finance/Table/F_origin_43/F_table_131_3.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_43",
-    "table_id": "F_table_131_3"
-  },
-  {
-    "index": 246,
-    "pair_id": "F_origin_43_F_table_131_4",
-    "image_paths": [
-      "data/Finance/Table/F_origin_43/F_table_131_4.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_43",
-    "table_id": "F_table_131_4"
-  },
-  {
-    "index": 247,
-    "pair_id": "F_origin_44_F_table_132_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_44/F_table_132_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_44",
-    "table_id": "F_table_132_0"
-  },
-  {
-    "index": 248,
-    "pair_id": "F_origin_44_F_table_132_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_44/F_table_132_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_44",
-    "table_id": "F_table_132_1"
-  },
-  {
-    "index": 249,
-    "pair_id": "F_origin_44_F_table_133_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_44/F_table_133_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_44",
-    "table_id": "F_table_133_0"
-  },
-  {
-    "index": 250,
-    "pair_id": "F_origin_44_F_table_133_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_44/F_table_133_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_44",
-    "table_id": "F_table_133_1"
-  },
-  {
-    "index": 251,
-    "pair_id": "F_origin_44_F_table_133_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_44/F_table_133_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_44",
-    "table_id": "F_table_133_2"
-  },
-  {
-    "index": 252,
-    "pair_id": "F_origin_44_F_table_134_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_44/F_table_134_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_44",
-    "table_id": "F_table_134_0"
-  },
-  {
-    "index": 253,
-    "pair_id": "F_origin_44_F_table_135_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_44/F_table_135_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_44",
-    "table_id": "F_table_135_0"
-  },
-  {
-    "index": 254,
-    "pair_id": "F_origin_44_F_table_135_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_44/F_table_135_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_44",
-    "table_id": "F_table_135_1"
-  },
-  {
-    "index": 255,
-    "pair_id": "F_origin_44_F_table_135_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_44/F_table_135_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_44",
-    "table_id": "F_table_135_2"
-  },
-  {
-    "index": 256,
-    "pair_id": "F_origin_45_F_table_136_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_45/F_table_136_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_45",
-    "table_id": "F_table_136_0"
-  },
-  {
-    "index": 257,
-    "pair_id": "F_origin_45_F_table_136_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_45/F_table_136_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_45",
-    "table_id": "F_table_136_1"
-  },
-  {
-    "index": 258,
-    "pair_id": "F_origin_45_F_table_136_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_45/F_table_136_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_45",
-    "table_id": "F_table_136_2"
-  },
-  {
-    "index": 259,
-    "pair_id": "F_origin_45_F_table_136_3",
-    "image_paths": [
-      "data/Finance/Table/F_origin_45/F_table_136_3.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_45",
-    "table_id": "F_table_136_3"
-  },
-  {
-    "index": 260,
-    "pair_id": "F_origin_45_F_table_136_4",
-    "image_paths": [
-      "data/Finance/Table/F_origin_45/F_table_136_4.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_45",
-    "table_id": "F_table_136_4"
-  },
-  {
-    "index": 261,
-    "pair_id": "F_origin_45_F_table_136_5",
-    "image_paths": [
-      "data/Finance/Table/F_origin_45/F_table_136_5.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_45",
-    "table_id": "F_table_136_5"
-  },
-  {
-    "index": 262,
-    "pair_id": "F_origin_46_F_table_137_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_46/F_table_137_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_46",
-    "table_id": "F_table_137_0"
-  },
-  {
-    "index": 263,
-    "pair_id": "F_origin_46_F_table_137_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_46/F_table_137_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_46",
-    "table_id": "F_table_137_1"
-  },
-  {
-    "index": 264,
-    "pair_id": "F_origin_46_F_table_138_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_46/F_table_138_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_46",
-    "table_id": "F_table_138_0"
-  },
-  {
-    "index": 265,
-    "pair_id": "F_origin_46_F_table_138_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_46/F_table_138_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_46",
-    "table_id": "F_table_138_1"
-  },
-  {
-    "index": 266,
-    "pair_id": "F_origin_46_F_table_139_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_46/F_table_139_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_46",
-    "table_id": "F_table_139_0"
-  },
-  {
-    "index": 267,
-    "pair_id": "F_origin_46_F_table_139_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_46/F_table_139_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_46",
-    "table_id": "F_table_139_1"
-  },
-  {
-    "index": 268,
-    "pair_id": "F_origin_47_F_table_140_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_47/F_table_140_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_47",
-    "table_id": "F_table_140_0"
-  },
-  {
-    "index": 269,
-    "pair_id": "F_origin_47_F_table_141_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_47/F_table_141_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_47",
-    "table_id": "F_table_141_0"
-  },
-  {
-    "index": 270,
-    "pair_id": "F_origin_47_F_table_141_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_47/F_table_141_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_47",
-    "table_id": "F_table_141_1"
-  },
-  {
-    "index": 271,
-    "pair_id": "F_origin_47_F_table_142_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_47/F_table_142_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_47",
-    "table_id": "F_table_142_0"
-  },
-  {
-    "index": 272,
-    "pair_id": "F_origin_47_F_table_142_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_47/F_table_142_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_47",
-    "table_id": "F_table_142_1"
-  },
-  {
-    "index": 273,
-    "pair_id": "F_origin_47_F_table_142_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_47/F_table_142_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_47",
-    "table_id": "F_table_142_2"
-  },
-  {
-    "index": 274,
-    "pair_id": "F_origin_47_F_table_142_3",
-    "image_paths": [
-      "data/Finance/Table/F_origin_47/F_table_142_3.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_47",
-    "table_id": "F_table_142_3"
-  },
-  {
-    "index": 275,
-    "pair_id": "F_origin_48_F_table_143_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_48/F_table_143_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_48",
-    "table_id": "F_table_143_0"
-  },
-  {
-    "index": 276,
-    "pair_id": "F_origin_48_F_table_144_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_48/F_table_144_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_48",
-    "table_id": "F_table_144_0"
-  },
-  {
-    "index": 277,
-    "pair_id": "F_origin_48_F_table_144_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_48/F_table_144_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_48",
-    "table_id": "F_table_144_1"
-  },
-  {
-    "index": 278,
-    "pair_id": "F_origin_48_F_table_145_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_48/F_table_145_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_48",
-    "table_id": "F_table_145_0"
-  },
-  {
-    "index": 279,
-    "pair_id": "F_origin_48_F_table_145_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_48/F_table_145_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_48",
-    "table_id": "F_table_145_1"
-  },
-  {
-    "index": 280,
-    "pair_id": "F_origin_49_F_table_146_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_49/F_table_146_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_49",
-    "table_id": "F_table_146_0"
-  },
-  {
-    "index": 281,
-    "pair_id": "F_origin_49_F_table_147_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_49/F_table_147_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_49",
-    "table_id": "F_table_147_0"
-  },
-  {
-    "index": 282,
-    "pair_id": "F_origin_49_F_table_147_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_49/F_table_147_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_49",
-    "table_id": "F_table_147_1"
-  },
-  {
-    "index": 283,
-    "pair_id": "F_origin_49_F_table_147_2",
-    "image_paths": [
-      "data/Finance/Table/F_origin_49/F_table_147_2.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_49",
-    "table_id": "F_table_147_2"
-  },
-  {
-    "index": 284,
-    "pair_id": "F_origin_49_F_table_148_0",
-    "image_paths": [
-      "data/Finance/Table/F_origin_49/F_table_148_0.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_49",
-    "table_id": "F_table_148_0"
-  },
-  {
-    "index": 285,
-    "pair_id": "F_origin_49_F_table_148_1",
-    "image_paths": [
-      "data/Finance/Table/F_origin_49/F_table_148_1.png"
-    ],
-    "domain": "Finance",
-    "origin": "F_origin_49",
-    "table_id": "F_table_148_1"
-  },
-  {
-    "index": 286,
+    "index": 36,
     "pair_id": "F_origin_5_F_table_7_0",
     "image_paths": [
       "data/Finance/Table/F_origin_5/F_table_7_0.png"
@@ -2870,7 +370,7 @@
     "table_id": "F_table_7_0"
   },
   {
-    "index": 287,
+    "index": 37,
     "pair_id": "F_origin_5_F_table_7_1",
     "image_paths": [
       "data/Finance/Table/F_origin_5/F_table_7_1.png"
@@ -2880,7 +380,7 @@
     "table_id": "F_table_7_1"
   },
   {
-    "index": 288,
+    "index": 38,
     "pair_id": "F_origin_5_F_table_7_2",
     "image_paths": [
       "data/Finance/Table/F_origin_5/F_table_7_2.png"
@@ -2890,7 +390,7 @@
     "table_id": "F_table_7_2"
   },
   {
-    "index": 289,
+    "index": 39,
     "pair_id": "F_origin_5_F_table_7_3",
     "image_paths": [
       "data/Finance/Table/F_origin_5/F_table_7_3.png"
@@ -2900,7 +400,7 @@
     "table_id": "F_table_7_3"
   },
   {
-    "index": 290,
+    "index": 40,
     "pair_id": "F_origin_5_F_table_7_4",
     "image_paths": [
       "data/Finance/Table/F_origin_5/F_table_7_4.png"
@@ -2910,7 +410,7 @@
     "table_id": "F_table_7_4"
   },
   {
-    "index": 291,
+    "index": 41,
     "pair_id": "F_origin_6_F_table_8_0",
     "image_paths": [
       "data/Finance/Table/F_origin_6/F_table_8_0.png"
@@ -2920,7 +420,7 @@
     "table_id": "F_table_8_0"
   },
   {
-    "index": 292,
+    "index": 42,
     "pair_id": "F_origin_6_F_table_8_1",
     "image_paths": [
       "data/Finance/Table/F_origin_6/F_table_8_1.png"
@@ -2930,7 +430,7 @@
     "table_id": "F_table_8_1"
   },
   {
-    "index": 293,
+    "index": 43,
     "pair_id": "F_origin_6_F_table_8_2",
     "image_paths": [
       "data/Finance/Table/F_origin_6/F_table_8_2.png"
@@ -2940,7 +440,7 @@
     "table_id": "F_table_8_2"
   },
   {
-    "index": 294,
+    "index": 44,
     "pair_id": "F_origin_6_F_table_8_3",
     "image_paths": [
       "data/Finance/Table/F_origin_6/F_table_8_3.png"
@@ -2950,7 +450,7 @@
     "table_id": "F_table_8_3"
   },
   {
-    "index": 295,
+    "index": 45,
     "pair_id": "F_origin_6_F_table_8_4",
     "image_paths": [
       "data/Finance/Table/F_origin_6/F_table_8_4.png"
@@ -2960,7 +460,7 @@
     "table_id": "F_table_8_4"
   },
   {
-    "index": 296,
+    "index": 46,
     "pair_id": "F_origin_6_F_table_9_0",
     "image_paths": [
       "data/Finance/Table/F_origin_6/F_table_9_0.png"
@@ -2970,7 +470,7 @@
     "table_id": "F_table_9_0"
   },
   {
-    "index": 297,
+    "index": 47,
     "pair_id": "F_origin_6_F_table_9_1",
     "image_paths": [
       "data/Finance/Table/F_origin_6/F_table_9_1.png"
@@ -2980,7 +480,7 @@
     "table_id": "F_table_9_1"
   },
   {
-    "index": 298,
+    "index": 48,
     "pair_id": "F_origin_7_F_table_10_0",
     "image_paths": [
       "data/Finance/Table/F_origin_7/F_table_10_0.png"
@@ -2990,7 +490,7 @@
     "table_id": "F_table_10_0"
   },
   {
-    "index": 299,
+    "index": 49,
     "pair_id": "F_origin_7_F_table_10_1",
     "image_paths": [
       "data/Finance/Table/F_origin_7/F_table_10_1.png"
@@ -3000,7 +500,7 @@
     "table_id": "F_table_10_1"
   },
   {
-    "index": 300,
+    "index": 50,
     "pair_id": "F_origin_7_F_table_10_2",
     "image_paths": [
       "data/Finance/Table/F_origin_7/F_table_10_2.png"
@@ -3010,7 +510,7 @@
     "table_id": "F_table_10_2"
   },
   {
-    "index": 301,
+    "index": 51,
     "pair_id": "F_origin_7_F_table_10_3",
     "image_paths": [
       "data/Finance/Table/F_origin_7/F_table_10_3.png"
@@ -3020,7 +520,7 @@
     "table_id": "F_table_10_3"
   },
   {
-    "index": 302,
+    "index": 52,
     "pair_id": "F_origin_7_F_table_10_4",
     "image_paths": [
       "data/Finance/Table/F_origin_7/F_table_10_4.png"
@@ -3030,7 +530,7 @@
     "table_id": "F_table_10_4"
   },
   {
-    "index": 303,
+    "index": 53,
     "pair_id": "F_origin_7_F_table_11_0",
     "image_paths": [
       "data/Finance/Table/F_origin_7/F_table_11_0.png"
@@ -3040,7 +540,7 @@
     "table_id": "F_table_11_0"
   },
   {
-    "index": 304,
+    "index": 54,
     "pair_id": "F_origin_7_F_table_11_1",
     "image_paths": [
       "data/Finance/Table/F_origin_7/F_table_11_1.png"
@@ -3050,7 +550,7 @@
     "table_id": "F_table_11_1"
   },
   {
-    "index": 305,
+    "index": 55,
     "pair_id": "F_origin_8_F_table_12_0",
     "image_paths": [
       "data/Finance/Table/F_origin_8/F_table_12_0.png"
@@ -3060,7 +560,7 @@
     "table_id": "F_table_12_0"
   },
   {
-    "index": 306,
+    "index": 56,
     "pair_id": "F_origin_8_F_table_12_1",
     "image_paths": [
       "data/Finance/Table/F_origin_8/F_table_12_1.png"
@@ -3070,7 +570,7 @@
     "table_id": "F_table_12_1"
   },
   {
-    "index": 307,
+    "index": 57,
     "pair_id": "F_origin_8_F_table_12_2",
     "image_paths": [
       "data/Finance/Table/F_origin_8/F_table_12_2.png"
@@ -3080,7 +580,7 @@
     "table_id": "F_table_12_2"
   },
   {
-    "index": 308,
+    "index": 58,
     "pair_id": "F_origin_8_F_table_12_3",
     "image_paths": [
       "data/Finance/Table/F_origin_8/F_table_12_3.png"
@@ -3090,7 +590,7 @@
     "table_id": "F_table_12_3"
   },
   {
-    "index": 309,
+    "index": 59,
     "pair_id": "F_origin_8_F_table_12_4",
     "image_paths": [
       "data/Finance/Table/F_origin_8/F_table_12_4.png"
@@ -3100,7 +600,7 @@
     "table_id": "F_table_12_4"
   },
   {
-    "index": 310,
+    "index": 60,
     "pair_id": "F_origin_9_F_table_13_0",
     "image_paths": [
       "data/Finance/Table/F_origin_9/F_table_13_0.png"
@@ -3110,7 +610,7 @@
     "table_id": "F_table_13_0"
   },
   {
-    "index": 311,
+    "index": 61,
     "pair_id": "F_origin_9_F_table_13_1",
     "image_paths": [
       "data/Finance/Table/F_origin_9/F_table_13_1.png"
@@ -3120,7 +620,7 @@
     "table_id": "F_table_13_1"
   },
   {
-    "index": 312,
+    "index": 62,
     "pair_id": "F_origin_9_F_table_13_2",
     "image_paths": [
       "data/Finance/Table/F_origin_9/F_table_13_2.png"
@@ -3130,7 +630,7 @@
     "table_id": "F_table_13_2"
   },
   {
-    "index": 313,
+    "index": 63,
     "pair_id": "F_origin_9_F_table_13_3",
     "image_paths": [
       "data/Finance/Table/F_origin_9/F_table_13_3.png"
@@ -3140,7 +640,7 @@
     "table_id": "F_table_13_3"
   },
   {
-    "index": 314,
+    "index": 64,
     "pair_id": "F_origin_9_F_table_13_4",
     "image_paths": [
       "data/Finance/Table/F_origin_9/F_table_13_4.png"
@@ -3148,5 +648,2135 @@
     "domain": "Finance",
     "origin": "F_origin_9",
     "table_id": "F_table_13_4"
+  },
+  {
+    "index": 65,
+    "pair_id": "F_origin_10_F_table_14_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_10/F_table_14_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_10",
+    "table_id": "F_table_14_0"
+  },
+  {
+    "index": 66,
+    "pair_id": "F_origin_10_F_table_14_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_10/F_table_14_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_10",
+    "table_id": "F_table_14_1"
+  },
+  {
+    "index": 67,
+    "pair_id": "F_origin_10_F_table_14_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_10/F_table_14_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_10",
+    "table_id": "F_table_14_2"
+  },
+  {
+    "index": 68,
+    "pair_id": "F_origin_10_F_table_14_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_10/F_table_14_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_10",
+    "table_id": "F_table_14_3"
+  },
+  {
+    "index": 69,
+    "pair_id": "F_origin_10_F_table_14_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_10/F_table_14_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_10",
+    "table_id": "F_table_14_4"
+  },
+  {
+    "index": 70,
+    "pair_id": "F_origin_11_F_table_15_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_11/F_table_15_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_11",
+    "table_id": "F_table_15_0"
+  },
+  {
+    "index": 71,
+    "pair_id": "F_origin_11_F_table_15_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_11/F_table_15_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_11",
+    "table_id": "F_table_15_1"
+  },
+  {
+    "index": 72,
+    "pair_id": "F_origin_11_F_table_15_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_11/F_table_15_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_11",
+    "table_id": "F_table_15_2"
+  },
+  {
+    "index": 73,
+    "pair_id": "F_origin_11_F_table_15_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_11/F_table_15_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_11",
+    "table_id": "F_table_15_3"
+  },
+  {
+    "index": 74,
+    "pair_id": "F_origin_11_F_table_15_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_11/F_table_15_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_11",
+    "table_id": "F_table_15_4"
+  },
+  {
+    "index": 75,
+    "pair_id": "F_origin_11_F_table_15_5",
+    "image_paths": [
+      "data/Finance/Table/F_origin_11/F_table_15_5.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_11",
+    "table_id": "F_table_15_5"
+  },
+  {
+    "index": 76,
+    "pair_id": "F_origin_12_F_table_16_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_12/F_table_16_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_12",
+    "table_id": "F_table_16_0"
+  },
+  {
+    "index": 77,
+    "pair_id": "F_origin_12_F_table_16_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_12/F_table_16_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_12",
+    "table_id": "F_table_16_1"
+  },
+  {
+    "index": 78,
+    "pair_id": "F_origin_12_F_table_16_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_12/F_table_16_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_12",
+    "table_id": "F_table_16_2"
+  },
+  {
+    "index": 79,
+    "pair_id": "F_origin_12_F_table_16_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_12/F_table_16_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_12",
+    "table_id": "F_table_16_3"
+  },
+  {
+    "index": 80,
+    "pair_id": "F_origin_12_F_table_16_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_12/F_table_16_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_12",
+    "table_id": "F_table_16_4"
+  },
+  {
+    "index": 81,
+    "pair_id": "F_origin_13_F_table_17_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_13/F_table_17_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_13",
+    "table_id": "F_table_17_0"
+  },
+  {
+    "index": 82,
+    "pair_id": "F_origin_13_F_table_17_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_13/F_table_17_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_13",
+    "table_id": "F_table_17_1"
+  },
+  {
+    "index": 83,
+    "pair_id": "F_origin_13_F_table_17_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_13/F_table_17_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_13",
+    "table_id": "F_table_17_2"
+  },
+  {
+    "index": 84,
+    "pair_id": "F_origin_13_F_table_17_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_13/F_table_17_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_13",
+    "table_id": "F_table_17_3"
+  },
+  {
+    "index": 85,
+    "pair_id": "F_origin_14_F_table_18_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_14/F_table_18_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_14",
+    "table_id": "F_table_18_0"
+  },
+  {
+    "index": 86,
+    "pair_id": "F_origin_14_F_table_18_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_14/F_table_18_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_14",
+    "table_id": "F_table_18_1"
+  },
+  {
+    "index": 87,
+    "pair_id": "F_origin_14_F_table_18_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_14/F_table_18_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_14",
+    "table_id": "F_table_18_2"
+  },
+  {
+    "index": 88,
+    "pair_id": "F_origin_14_F_table_18_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_14/F_table_18_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_14",
+    "table_id": "F_table_18_3"
+  },
+  {
+    "index": 89,
+    "pair_id": "F_origin_14_F_table_18_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_14/F_table_18_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_14",
+    "table_id": "F_table_18_4"
+  },
+  {
+    "index": 90,
+    "pair_id": "F_origin_15_F_table_19_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_15/F_table_19_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_15",
+    "table_id": "F_table_19_0"
+  },
+  {
+    "index": 91,
+    "pair_id": "F_origin_15_F_table_19_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_15/F_table_19_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_15",
+    "table_id": "F_table_19_1"
+  },
+  {
+    "index": 92,
+    "pair_id": "F_origin_15_F_table_19_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_15/F_table_19_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_15",
+    "table_id": "F_table_19_2"
+  },
+  {
+    "index": 93,
+    "pair_id": "F_origin_15_F_table_19_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_15/F_table_19_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_15",
+    "table_id": "F_table_19_3"
+  },
+  {
+    "index": 94,
+    "pair_id": "F_origin_15_F_table_19_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_15/F_table_19_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_15",
+    "table_id": "F_table_19_4"
+  },
+  {
+    "index": 95,
+    "pair_id": "F_origin_16_F_table_20_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_16/F_table_20_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_16",
+    "table_id": "F_table_20_0"
+  },
+  {
+    "index": 96,
+    "pair_id": "F_origin_16_F_table_20_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_16/F_table_20_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_16",
+    "table_id": "F_table_20_1"
+  },
+  {
+    "index": 97,
+    "pair_id": "F_origin_16_F_table_20_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_16/F_table_20_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_16",
+    "table_id": "F_table_20_2"
+  },
+  {
+    "index": 98,
+    "pair_id": "F_origin_16_F_table_20_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_16/F_table_20_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_16",
+    "table_id": "F_table_20_3"
+  },
+  {
+    "index": 99,
+    "pair_id": "F_origin_16_F_table_20_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_16/F_table_20_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_16",
+    "table_id": "F_table_20_4"
+  },
+  {
+    "index": 100,
+    "pair_id": "F_origin_16_F_table_20_5",
+    "image_paths": [
+      "data/Finance/Table/F_origin_16/F_table_20_5.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_16",
+    "table_id": "F_table_20_5"
+  },
+  {
+    "index": 101,
+    "pair_id": "F_origin_16_F_table_21_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_16/F_table_21_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_16",
+    "table_id": "F_table_21_0"
+  },
+  {
+    "index": 102,
+    "pair_id": "F_origin_16_F_table_21_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_16/F_table_21_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_16",
+    "table_id": "F_table_21_1"
+  },
+  {
+    "index": 103,
+    "pair_id": "F_origin_17_F_table_22_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_17/F_table_22_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_17",
+    "table_id": "F_table_22_0"
+  },
+  {
+    "index": 104,
+    "pair_id": "F_origin_17_F_table_22_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_17/F_table_22_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_17",
+    "table_id": "F_table_22_1"
+  },
+  {
+    "index": 105,
+    "pair_id": "F_origin_17_F_table_22_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_17/F_table_22_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_17",
+    "table_id": "F_table_22_2"
+  },
+  {
+    "index": 106,
+    "pair_id": "F_origin_17_F_table_22_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_17/F_table_22_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_17",
+    "table_id": "F_table_22_3"
+  },
+  {
+    "index": 107,
+    "pair_id": "F_origin_17_F_table_22_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_17/F_table_22_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_17",
+    "table_id": "F_table_22_4"
+  },
+  {
+    "index": 108,
+    "pair_id": "F_origin_18_F_table_23_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_18/F_table_23_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_18",
+    "table_id": "F_table_23_0"
+  },
+  {
+    "index": 109,
+    "pair_id": "F_origin_18_F_table_23_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_18/F_table_23_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_18",
+    "table_id": "F_table_23_1"
+  },
+  {
+    "index": 110,
+    "pair_id": "F_origin_18_F_table_23_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_18/F_table_23_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_18",
+    "table_id": "F_table_23_2"
+  },
+  {
+    "index": 111,
+    "pair_id": "F_origin_18_F_table_23_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_18/F_table_23_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_18",
+    "table_id": "F_table_23_3"
+  },
+  {
+    "index": 112,
+    "pair_id": "F_origin_19_F_table_24_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_19/F_table_24_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_19",
+    "table_id": "F_table_24_0"
+  },
+  {
+    "index": 113,
+    "pair_id": "F_origin_19_F_table_24_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_19/F_table_24_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_19",
+    "table_id": "F_table_24_1"
+  },
+  {
+    "index": 114,
+    "pair_id": "F_origin_19_F_table_24_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_19/F_table_24_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_19",
+    "table_id": "F_table_24_2"
+  },
+  {
+    "index": 115,
+    "pair_id": "F_origin_19_F_table_24_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_19/F_table_24_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_19",
+    "table_id": "F_table_24_3"
+  },
+  {
+    "index": 116,
+    "pair_id": "F_origin_19_F_table_24_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_19/F_table_24_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_19",
+    "table_id": "F_table_24_4"
+  },
+  {
+    "index": 117,
+    "pair_id": "F_origin_19_F_table_24_5",
+    "image_paths": [
+      "data/Finance/Table/F_origin_19/F_table_24_5.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_19",
+    "table_id": "F_table_24_5"
+  },
+  {
+    "index": 118,
+    "pair_id": "F_origin_19_F_table_24_6",
+    "image_paths": [
+      "data/Finance/Table/F_origin_19/F_table_24_6.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_19",
+    "table_id": "F_table_24_6"
+  },
+  {
+    "index": 119,
+    "pair_id": "F_origin_19_F_table_24_7",
+    "image_paths": [
+      "data/Finance/Table/F_origin_19/F_table_24_7.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_19",
+    "table_id": "F_table_24_7"
+  },
+  {
+    "index": 120,
+    "pair_id": "F_origin_19_F_table_24_8",
+    "image_paths": [
+      "data/Finance/Table/F_origin_19/F_table_24_8.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_19",
+    "table_id": "F_table_24_8"
+  },
+  {
+    "index": 121,
+    "pair_id": "F_origin_20_F_table_25_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_20/F_table_25_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_20",
+    "table_id": "F_table_25_0"
+  },
+  {
+    "index": 122,
+    "pair_id": "F_origin_20_F_table_25_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_20/F_table_25_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_20",
+    "table_id": "F_table_25_1"
+  },
+  {
+    "index": 123,
+    "pair_id": "F_origin_20_F_table_25_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_20/F_table_25_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_20",
+    "table_id": "F_table_25_2"
+  },
+  {
+    "index": 124,
+    "pair_id": "F_origin_20_F_table_25_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_20/F_table_25_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_20",
+    "table_id": "F_table_25_3"
+  },
+  {
+    "index": 125,
+    "pair_id": "F_origin_20_F_table_25_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_20/F_table_25_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_20",
+    "table_id": "F_table_25_4"
+  },
+  {
+    "index": 126,
+    "pair_id": "F_origin_20_F_table_25_5",
+    "image_paths": [
+      "data/Finance/Table/F_origin_20/F_table_25_5.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_20",
+    "table_id": "F_table_25_5"
+  },
+  {
+    "index": 127,
+    "pair_id": "F_origin_20_F_table_25_6",
+    "image_paths": [
+      "data/Finance/Table/F_origin_20/F_table_25_6.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_20",
+    "table_id": "F_table_25_6"
+  },
+  {
+    "index": 128,
+    "pair_id": "F_origin_20_F_table_25_7",
+    "image_paths": [
+      "data/Finance/Table/F_origin_20/F_table_25_7.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_20",
+    "table_id": "F_table_25_7"
+  },
+  {
+    "index": 129,
+    "pair_id": "F_origin_20_F_table_25_8",
+    "image_paths": [
+      "data/Finance/Table/F_origin_20/F_table_25_8.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_20",
+    "table_id": "F_table_25_8"
+  },
+  {
+    "index": 130,
+    "pair_id": "F_origin_21_F_table_26_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_21/F_table_26_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_21",
+    "table_id": "F_table_26_0"
+  },
+  {
+    "index": 131,
+    "pair_id": "F_origin_21_F_table_26_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_21/F_table_26_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_21",
+    "table_id": "F_table_26_1"
+  },
+  {
+    "index": 132,
+    "pair_id": "F_origin_21_F_table_26_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_21/F_table_26_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_21",
+    "table_id": "F_table_26_2"
+  },
+  {
+    "index": 133,
+    "pair_id": "F_origin_21_F_table_26_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_21/F_table_26_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_21",
+    "table_id": "F_table_26_3"
+  },
+  {
+    "index": 134,
+    "pair_id": "F_origin_21_F_table_26_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_21/F_table_26_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_21",
+    "table_id": "F_table_26_4"
+  },
+  {
+    "index": 135,
+    "pair_id": "F_origin_22_F_table_27_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_22/F_table_27_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_22",
+    "table_id": "F_table_27_0"
+  },
+  {
+    "index": 136,
+    "pair_id": "F_origin_22_F_table_27_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_22/F_table_27_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_22",
+    "table_id": "F_table_27_1"
+  },
+  {
+    "index": 137,
+    "pair_id": "F_origin_22_F_table_27_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_22/F_table_27_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_22",
+    "table_id": "F_table_27_2"
+  },
+  {
+    "index": 138,
+    "pair_id": "F_origin_22_F_table_27_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_22/F_table_27_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_22",
+    "table_id": "F_table_27_3"
+  },
+  {
+    "index": 139,
+    "pair_id": "F_origin_22_F_table_27_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_22/F_table_27_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_22",
+    "table_id": "F_table_27_4"
+  },
+  {
+    "index": 140,
+    "pair_id": "F_origin_22_F_table_27_5",
+    "image_paths": [
+      "data/Finance/Table/F_origin_22/F_table_27_5.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_22",
+    "table_id": "F_table_27_5"
+  },
+  {
+    "index": 141,
+    "pair_id": "F_origin_22_F_table_27_6",
+    "image_paths": [
+      "data/Finance/Table/F_origin_22/F_table_27_6.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_22",
+    "table_id": "F_table_27_6"
+  },
+  {
+    "index": 142,
+    "pair_id": "F_origin_23_F_table_28_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_23/F_table_28_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_23",
+    "table_id": "F_table_28_0"
+  },
+  {
+    "index": 143,
+    "pair_id": "F_origin_23_F_table_28_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_23/F_table_28_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_23",
+    "table_id": "F_table_28_1"
+  },
+  {
+    "index": 144,
+    "pair_id": "F_origin_23_F_table_28_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_23/F_table_28_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_23",
+    "table_id": "F_table_28_2"
+  },
+  {
+    "index": 145,
+    "pair_id": "F_origin_23_F_table_28_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_23/F_table_28_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_23",
+    "table_id": "F_table_28_3"
+  },
+  {
+    "index": 146,
+    "pair_id": "F_origin_23_F_table_28_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_23/F_table_28_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_23",
+    "table_id": "F_table_28_4"
+  },
+  {
+    "index": 147,
+    "pair_id": "F_origin_23_F_table_28_5",
+    "image_paths": [
+      "data/Finance/Table/F_origin_23/F_table_28_5.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_23",
+    "table_id": "F_table_28_5"
+  },
+  {
+    "index": 148,
+    "pair_id": "F_origin_23_F_table_28_6",
+    "image_paths": [
+      "data/Finance/Table/F_origin_23/F_table_28_6.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_23",
+    "table_id": "F_table_28_6"
+  },
+  {
+    "index": 149,
+    "pair_id": "F_origin_24_F_table_29_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_24/F_table_29_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_24",
+    "table_id": "F_table_29_0"
+  },
+  {
+    "index": 150,
+    "pair_id": "F_origin_24_F_table_29_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_24/F_table_29_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_24",
+    "table_id": "F_table_29_1"
+  },
+  {
+    "index": 151,
+    "pair_id": "F_origin_24_F_table_29_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_24/F_table_29_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_24",
+    "table_id": "F_table_29_2"
+  },
+  {
+    "index": 152,
+    "pair_id": "F_origin_24_F_table_29_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_24/F_table_29_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_24",
+    "table_id": "F_table_29_3"
+  },
+  {
+    "index": 153,
+    "pair_id": "F_origin_24_F_table_29_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_24/F_table_29_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_24",
+    "table_id": "F_table_29_4"
+  },
+  {
+    "index": 154,
+    "pair_id": "F_origin_24_F_table_29_5",
+    "image_paths": [
+      "data/Finance/Table/F_origin_24/F_table_29_5.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_24",
+    "table_id": "F_table_29_5"
+  },
+  {
+    "index": 155,
+    "pair_id": "F_origin_24_F_table_29_6",
+    "image_paths": [
+      "data/Finance/Table/F_origin_24/F_table_29_6.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_24",
+    "table_id": "F_table_29_6"
+  },
+  {
+    "index": 156,
+    "pair_id": "F_origin_24_F_table_29_7",
+    "image_paths": [
+      "data/Finance/Table/F_origin_24/F_table_29_7.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_24",
+    "table_id": "F_table_29_7"
+  },
+  {
+    "index": 157,
+    "pair_id": "F_origin_24_F_table_29_8",
+    "image_paths": [
+      "data/Finance/Table/F_origin_24/F_table_29_8.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_24",
+    "table_id": "F_table_29_8"
+  },
+  {
+    "index": 158,
+    "pair_id": "F_origin_24_F_table_29_9",
+    "image_paths": [
+      "data/Finance/Table/F_origin_24/F_table_29_9.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_24",
+    "table_id": "F_table_29_9"
+  },
+  {
+    "index": 159,
+    "pair_id": "F_origin_24_F_table_29_10",
+    "image_paths": [
+      "data/Finance/Table/F_origin_24/F_table_29_10.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_24",
+    "table_id": "F_table_29_10"
+  },
+  {
+    "index": 160,
+    "pair_id": "F_origin_24_F_table_29_11",
+    "image_paths": [
+      "data/Finance/Table/F_origin_24/F_table_29_11.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_24",
+    "table_id": "F_table_29_11"
+  },
+  {
+    "index": 161,
+    "pair_id": "F_origin_24_F_table_29_12",
+    "image_paths": [
+      "data/Finance/Table/F_origin_24/F_table_29_12.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_24",
+    "table_id": "F_table_29_12"
+  },
+  {
+    "index": 162,
+    "pair_id": "F_origin_24_F_table_29_13",
+    "image_paths": [
+      "data/Finance/Table/F_origin_24/F_table_29_13.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_24",
+    "table_id": "F_table_29_13"
+  },
+  {
+    "index": 163,
+    "pair_id": "F_origin_25_F_table_30_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_25/F_table_30_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_25",
+    "table_id": "F_table_30_0"
+  },
+  {
+    "index": 164,
+    "pair_id": "F_origin_25_F_table_30_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_25/F_table_30_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_25",
+    "table_id": "F_table_30_1"
+  },
+  {
+    "index": 165,
+    "pair_id": "F_origin_25_F_table_30_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_25/F_table_30_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_25",
+    "table_id": "F_table_30_2"
+  },
+  {
+    "index": 166,
+    "pair_id": "F_origin_25_F_table_30_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_25/F_table_30_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_25",
+    "table_id": "F_table_30_3"
+  },
+  {
+    "index": 167,
+    "pair_id": "F_origin_25_F_table_30_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_25/F_table_30_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_25",
+    "table_id": "F_table_30_4"
+  },
+  {
+    "index": 168,
+    "pair_id": "F_origin_25_F_table_30_5",
+    "image_paths": [
+      "data/Finance/Table/F_origin_25/F_table_30_5.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_25",
+    "table_id": "F_table_30_5"
+  },
+  {
+    "index": 169,
+    "pair_id": "F_origin_25_F_table_30_6",
+    "image_paths": [
+      "data/Finance/Table/F_origin_25/F_table_30_6.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_25",
+    "table_id": "F_table_30_6"
+  },
+  {
+    "index": 170,
+    "pair_id": "F_origin_26_F_table_31_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_26/F_table_31_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_26",
+    "table_id": "F_table_31_0"
+  },
+  {
+    "index": 171,
+    "pair_id": "F_origin_26_F_table_31_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_26/F_table_31_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_26",
+    "table_id": "F_table_31_1"
+  },
+  {
+    "index": 172,
+    "pair_id": "F_origin_26_F_table_31_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_26/F_table_31_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_26",
+    "table_id": "F_table_31_2"
+  },
+  {
+    "index": 173,
+    "pair_id": "F_origin_26_F_table_31_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_26/F_table_31_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_26",
+    "table_id": "F_table_31_3"
+  },
+  {
+    "index": 174,
+    "pair_id": "F_origin_26_F_table_31_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_26/F_table_31_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_26",
+    "table_id": "F_table_31_4"
+  },
+  {
+    "index": 175,
+    "pair_id": "F_origin_27_F_table_32_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_27/F_table_32_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_27",
+    "table_id": "F_table_32_0"
+  },
+  {
+    "index": 176,
+    "pair_id": "F_origin_27_F_table_32_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_27/F_table_32_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_27",
+    "table_id": "F_table_32_1"
+  },
+  {
+    "index": 177,
+    "pair_id": "F_origin_27_F_table_32_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_27/F_table_32_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_27",
+    "table_id": "F_table_32_2"
+  },
+  {
+    "index": 178,
+    "pair_id": "F_origin_27_F_table_32_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_27/F_table_32_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_27",
+    "table_id": "F_table_32_3"
+  },
+  {
+    "index": 179,
+    "pair_id": "F_origin_27_F_table_32_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_27/F_table_32_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_27",
+    "table_id": "F_table_32_4"
+  },
+  {
+    "index": 180,
+    "pair_id": "F_origin_27_F_table_32_5",
+    "image_paths": [
+      "data/Finance/Table/F_origin_27/F_table_32_5.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_27",
+    "table_id": "F_table_32_5"
+  },
+  {
+    "index": 181,
+    "pair_id": "F_origin_28_F_table_33_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_28/F_table_33_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_28",
+    "table_id": "F_table_33_0"
+  },
+  {
+    "index": 182,
+    "pair_id": "F_origin_28_F_table_33_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_28/F_table_33_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_28",
+    "table_id": "F_table_33_1"
+  },
+  {
+    "index": 183,
+    "pair_id": "F_origin_28_F_table_33_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_28/F_table_33_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_28",
+    "table_id": "F_table_33_2"
+  },
+  {
+    "index": 184,
+    "pair_id": "F_origin_28_F_table_33_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_28/F_table_33_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_28",
+    "table_id": "F_table_33_3"
+  },
+  {
+    "index": 185,
+    "pair_id": "F_origin_28_F_table_33_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_28/F_table_33_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_28",
+    "table_id": "F_table_33_4"
+  },
+  {
+    "index": 186,
+    "pair_id": "F_origin_29_F_table_34_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_29/F_table_34_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_29",
+    "table_id": "F_table_34_0"
+  },
+  {
+    "index": 187,
+    "pair_id": "F_origin_29_F_table_34_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_29/F_table_34_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_29",
+    "table_id": "F_table_34_1"
+  },
+  {
+    "index": 188,
+    "pair_id": "F_origin_29_F_table_34_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_29/F_table_34_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_29",
+    "table_id": "F_table_34_2"
+  },
+  {
+    "index": 189,
+    "pair_id": "F_origin_29_F_table_34_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_29/F_table_34_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_29",
+    "table_id": "F_table_34_3"
+  },
+  {
+    "index": 190,
+    "pair_id": "F_origin_29_F_table_34_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_29/F_table_34_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_29",
+    "table_id": "F_table_34_4"
+  },
+  {
+    "index": 191,
+    "pair_id": "F_origin_29_F_table_34_5",
+    "image_paths": [
+      "data/Finance/Table/F_origin_29/F_table_34_5.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_29",
+    "table_id": "F_table_34_5"
+  },
+  {
+    "index": 192,
+    "pair_id": "F_origin_30_F_table_34_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_30/F_table_34_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_30",
+    "table_id": "F_table_34_0"
+  },
+  {
+    "index": 193,
+    "pair_id": "F_origin_30_F_table_34_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_30/F_table_34_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_30",
+    "table_id": "F_table_34_1"
+  },
+  {
+    "index": 194,
+    "pair_id": "F_origin_30_F_table_34_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_30/F_table_34_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_30",
+    "table_id": "F_table_34_2"
+  },
+  {
+    "index": 195,
+    "pair_id": "F_origin_31_F_table_35_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_31/F_table_35_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_31",
+    "table_id": "F_table_35_0"
+  },
+  {
+    "index": 196,
+    "pair_id": "F_origin_31_F_table_35_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_31/F_table_35_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_31",
+    "table_id": "F_table_35_1"
+  },
+  {
+    "index": 197,
+    "pair_id": "F_origin_31_F_table_35_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_31/F_table_35_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_31",
+    "table_id": "F_table_35_2"
+  },
+  {
+    "index": 198,
+    "pair_id": "F_origin_32_F_table_36_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_32/F_table_36_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_32",
+    "table_id": "F_table_36_0"
+  },
+  {
+    "index": 199,
+    "pair_id": "F_origin_32_F_table_36_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_32/F_table_36_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_32",
+    "table_id": "F_table_36_1"
+  },
+  {
+    "index": 200,
+    "pair_id": "F_origin_32_F_table_36_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_32/F_table_36_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_32",
+    "table_id": "F_table_36_2"
+  },
+  {
+    "index": 201,
+    "pair_id": "F_origin_33_F_table_37_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_33/F_table_37_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_33",
+    "table_id": "F_table_37_0"
+  },
+  {
+    "index": 202,
+    "pair_id": "F_origin_33_F_table_37_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_33/F_table_37_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_33",
+    "table_id": "F_table_37_1"
+  },
+  {
+    "index": 203,
+    "pair_id": "F_origin_33_F_table_37_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_33/F_table_37_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_33",
+    "table_id": "F_table_37_2"
+  },
+  {
+    "index": 204,
+    "pair_id": "F_origin_34_F_table_38_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_34/F_table_38_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_34",
+    "table_id": "F_table_38_0"
+  },
+  {
+    "index": 205,
+    "pair_id": "F_origin_34_F_table_38_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_34/F_table_38_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_34",
+    "table_id": "F_table_38_1"
+  },
+  {
+    "index": 206,
+    "pair_id": "F_origin_34_F_table_38_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_34/F_table_38_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_34",
+    "table_id": "F_table_38_2"
+  },
+  {
+    "index": 207,
+    "pair_id": "F_origin_35_F_table_39_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_35/F_table_39_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_35",
+    "table_id": "F_table_39_0"
+  },
+  {
+    "index": 208,
+    "pair_id": "F_origin_35_F_table_39_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_35/F_table_39_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_35",
+    "table_id": "F_table_39_1"
+  },
+  {
+    "index": 209,
+    "pair_id": "F_origin_35_F_table_39_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_35/F_table_39_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_35",
+    "table_id": "F_table_39_2"
+  },
+  {
+    "index": 210,
+    "pair_id": "F_origin_36_F_table_40_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_36/F_table_40_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_36",
+    "table_id": "F_table_40_0"
+  },
+  {
+    "index": 211,
+    "pair_id": "F_origin_36_F_table_40_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_36/F_table_40_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_36",
+    "table_id": "F_table_40_1"
+  },
+  {
+    "index": 212,
+    "pair_id": "F_origin_36_F_table_40_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_36/F_table_40_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_36",
+    "table_id": "F_table_40_2"
+  },
+  {
+    "index": 213,
+    "pair_id": "F_origin_36_F_table_40_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_36/F_table_40_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_36",
+    "table_id": "F_table_40_3"
+  },
+  {
+    "index": 214,
+    "pair_id": "F_origin_37_F_table_41_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_37/F_table_41_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_37",
+    "table_id": "F_table_41_0"
+  },
+  {
+    "index": 215,
+    "pair_id": "F_origin_37_F_table_41_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_37/F_table_41_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_37",
+    "table_id": "F_table_41_1"
+  },
+  {
+    "index": 216,
+    "pair_id": "F_origin_37_F_table_41_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_37/F_table_41_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_37",
+    "table_id": "F_table_41_2"
+  },
+  {
+    "index": 217,
+    "pair_id": "F_origin_37_F_table_41_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_37/F_table_41_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_37",
+    "table_id": "F_table_41_3"
+  },
+  {
+    "index": 218,
+    "pair_id": "F_origin_37_F_table_41_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_37/F_table_41_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_37",
+    "table_id": "F_table_41_4"
+  },
+  {
+    "index": 219,
+    "pair_id": "F_origin_38_F_table_42_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_38/F_table_42_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_38",
+    "table_id": "F_table_42_0"
+  },
+  {
+    "index": 220,
+    "pair_id": "F_origin_38_F_table_42_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_38/F_table_42_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_38",
+    "table_id": "F_table_42_1"
+  },
+  {
+    "index": 221,
+    "pair_id": "F_origin_38_F_table_42_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_38/F_table_42_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_38",
+    "table_id": "F_table_42_2"
+  },
+  {
+    "index": 222,
+    "pair_id": "F_origin_39_F_table_43_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_39/F_table_43_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_39",
+    "table_id": "F_table_43_0"
+  },
+  {
+    "index": 223,
+    "pair_id": "F_origin_39_F_table_43_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_39/F_table_43_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_39",
+    "table_id": "F_table_43_1"
+  },
+  {
+    "index": 224,
+    "pair_id": "F_origin_39_F_table_43_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_39/F_table_43_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_39",
+    "table_id": "F_table_43_2"
+  },
+  {
+    "index": 225,
+    "pair_id": "F_origin_40_F_table_44_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_40/F_table_44_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_40",
+    "table_id": "F_table_44_0"
+  },
+  {
+    "index": 226,
+    "pair_id": "F_origin_40_F_table_44_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_40/F_table_44_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_40",
+    "table_id": "F_table_44_1"
+  },
+  {
+    "index": 227,
+    "pair_id": "F_origin_40_F_table_44_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_40/F_table_44_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_40",
+    "table_id": "F_table_44_2"
+  },
+  {
+    "index": 228,
+    "pair_id": "F_origin_41_F_table_45_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_41/F_table_45_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_41",
+    "table_id": "F_table_45_0"
+  },
+  {
+    "index": 229,
+    "pair_id": "F_origin_41_F_table_45_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_41/F_table_45_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_41",
+    "table_id": "F_table_45_1"
+  },
+  {
+    "index": 230,
+    "pair_id": "F_origin_41_F_table_45_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_41/F_table_45_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_41",
+    "table_id": "F_table_45_2"
+  },
+  {
+    "index": 231,
+    "pair_id": "F_origin_41_F_table_45_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_41/F_table_45_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_41",
+    "table_id": "F_table_45_3"
+  },
+  {
+    "index": 232,
+    "pair_id": "F_origin_41_F_table_45_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_41/F_table_45_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_41",
+    "table_id": "F_table_45_4"
+  },
+  {
+    "index": 233,
+    "pair_id": "F_origin_41_F_table_45_5",
+    "image_paths": [
+      "data/Finance/Table/F_origin_41/F_table_45_5.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_41",
+    "table_id": "F_table_45_5"
+  },
+  {
+    "index": 234,
+    "pair_id": "F_origin_42_F_table_46_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_42/F_table_46_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_42",
+    "table_id": "F_table_46_0"
+  },
+  {
+    "index": 235,
+    "pair_id": "F_origin_42_F_table_46_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_42/F_table_46_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_42",
+    "table_id": "F_table_46_1"
+  },
+  {
+    "index": 236,
+    "pair_id": "F_origin_42_F_table_46_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_42/F_table_46_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_42",
+    "table_id": "F_table_46_2"
+  },
+  {
+    "index": 237,
+    "pair_id": "F_origin_42_F_table_46_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_42/F_table_46_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_42",
+    "table_id": "F_table_46_3"
+  },
+  {
+    "index": 238,
+    "pair_id": "F_origin_43_F_table_47_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_43/F_table_47_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_43",
+    "table_id": "F_table_47_0"
+  },
+  {
+    "index": 239,
+    "pair_id": "F_origin_43_F_table_47_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_43/F_table_47_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_43",
+    "table_id": "F_table_47_1"
+  },
+  {
+    "index": 240,
+    "pair_id": "F_origin_43_F_table_47_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_43/F_table_47_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_43",
+    "table_id": "F_table_47_2"
+  },
+  {
+    "index": 241,
+    "pair_id": "F_origin_43_F_table_47_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_43/F_table_47_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_43",
+    "table_id": "F_table_47_3"
+  },
+  {
+    "index": 242,
+    "pair_id": "F_origin_44_F_table_48_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_44/F_table_48_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_44",
+    "table_id": "F_table_48_0"
+  },
+  {
+    "index": 243,
+    "pair_id": "F_origin_44_F_table_48_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_44/F_table_48_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_44",
+    "table_id": "F_table_48_1"
+  },
+  {
+    "index": 244,
+    "pair_id": "F_origin_44_F_table_48_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_44/F_table_48_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_44",
+    "table_id": "F_table_48_2"
+  },
+  {
+    "index": 245,
+    "pair_id": "F_origin_44_F_table_48_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_44/F_table_48_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_44",
+    "table_id": "F_table_48_3"
+  },
+  {
+    "index": 246,
+    "pair_id": "F_origin_44_F_table_48_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_44/F_table_48_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_44",
+    "table_id": "F_table_48_4"
+  },
+  {
+    "index": 247,
+    "pair_id": "F_origin_44_F_table_48_5",
+    "image_paths": [
+      "data/Finance/Table/F_origin_44/F_table_48_5.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_44",
+    "table_id": "F_table_48_5"
+  },
+  {
+    "index": 248,
+    "pair_id": "F_origin_44_F_table_48_6",
+    "image_paths": [
+      "data/Finance/Table/F_origin_44/F_table_48_6.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_44",
+    "table_id": "F_table_48_6"
+  },
+  {
+    "index": 249,
+    "pair_id": "F_origin_45_F_table_49_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_45/F_table_49_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_45",
+    "table_id": "F_table_49_0"
+  },
+  {
+    "index": 250,
+    "pair_id": "F_origin_45_F_table_49_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_45/F_table_49_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_45",
+    "table_id": "F_table_49_1"
+  },
+  {
+    "index": 251,
+    "pair_id": "F_origin_45_F_table_49_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_45/F_table_49_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_45",
+    "table_id": "F_table_49_2"
+  },
+  {
+    "index": 252,
+    "pair_id": "F_origin_45_F_table_49_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_45/F_table_49_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_45",
+    "table_id": "F_table_49_3"
+  },
+  {
+    "index": 253,
+    "pair_id": "F_origin_45_F_table_49_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_45/F_table_49_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_45",
+    "table_id": "F_table_49_4"
+  },
+  {
+    "index": 254,
+    "pair_id": "F_origin_46_F_table_49_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_46/F_table_49_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_46",
+    "table_id": "F_table_49_0"
+  },
+  {
+    "index": 255,
+    "pair_id": "F_origin_46_F_table_49_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_46/F_table_49_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_46",
+    "table_id": "F_table_49_1"
+  },
+  {
+    "index": 256,
+    "pair_id": "F_origin_46_F_table_49_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_46/F_table_49_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_46",
+    "table_id": "F_table_49_2"
+  },
+  {
+    "index": 257,
+    "pair_id": "F_origin_46_F_table_49_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_46/F_table_49_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_46",
+    "table_id": "F_table_49_3"
+  },
+  {
+    "index": 258,
+    "pair_id": "F_origin_46_F_table_49_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_46/F_table_49_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_46",
+    "table_id": "F_table_49_4"
+  },
+  {
+    "index": 259,
+    "pair_id": "F_origin_46_F_table_49_5",
+    "image_paths": [
+      "data/Finance/Table/F_origin_46/F_table_49_5.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_46",
+    "table_id": "F_table_49_5"
+  },
+  {
+    "index": 260,
+    "pair_id": "F_origin_47_F_table_50_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_47/F_table_50_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_47",
+    "table_id": "F_table_50_0"
+  },
+  {
+    "index": 261,
+    "pair_id": "F_origin_47_F_table_50_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_47/F_table_50_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_47",
+    "table_id": "F_table_50_1"
+  },
+  {
+    "index": 262,
+    "pair_id": "F_origin_47_F_table_50_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_47/F_table_50_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_47",
+    "table_id": "F_table_50_2"
+  },
+  {
+    "index": 263,
+    "pair_id": "F_origin_47_F_table_50_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_47/F_table_50_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_47",
+    "table_id": "F_table_50_3"
+  },
+  {
+    "index": 264,
+    "pair_id": "F_origin_47_F_table_50_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_47/F_table_50_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_47",
+    "table_id": "F_table_50_4"
+  },
+  {
+    "index": 265,
+    "pair_id": "F_origin_47_F_table_50_5",
+    "image_paths": [
+      "data/Finance/Table/F_origin_47/F_table_50_5.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_47",
+    "table_id": "F_table_50_5"
+  },
+  {
+    "index": 266,
+    "pair_id": "F_origin_47_F_table_50_6",
+    "image_paths": [
+      "data/Finance/Table/F_origin_47/F_table_50_6.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_47",
+    "table_id": "F_table_50_6"
+  },
+  {
+    "index": 267,
+    "pair_id": "F_origin_48_F_table_51_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_48/F_table_51_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_48",
+    "table_id": "F_table_51_0"
+  },
+  {
+    "index": 268,
+    "pair_id": "F_origin_48_F_table_51_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_48/F_table_51_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_48",
+    "table_id": "F_table_51_1"
+  },
+  {
+    "index": 269,
+    "pair_id": "F_origin_48_F_table_51_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_48/F_table_51_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_48",
+    "table_id": "F_table_51_2"
+  },
+  {
+    "index": 270,
+    "pair_id": "F_origin_48_F_table_51_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_48/F_table_51_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_48",
+    "table_id": "F_table_51_3"
+  },
+  {
+    "index": 271,
+    "pair_id": "F_origin_48_F_table_51_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_48/F_table_51_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_48",
+    "table_id": "F_table_51_4"
+  },
+  {
+    "index": 272,
+    "pair_id": "F_origin_49_F_table_52_0",
+    "image_paths": [
+      "data/Finance/Table/F_origin_49/F_table_52_0.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_49",
+    "table_id": "F_table_52_0"
+  },
+  {
+    "index": 273,
+    "pair_id": "F_origin_49_F_table_52_1",
+    "image_paths": [
+      "data/Finance/Table/F_origin_49/F_table_52_1.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_49",
+    "table_id": "F_table_52_1"
+  },
+  {
+    "index": 274,
+    "pair_id": "F_origin_49_F_table_52_2",
+    "image_paths": [
+      "data/Finance/Table/F_origin_49/F_table_52_2.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_49",
+    "table_id": "F_table_52_2"
+  },
+  {
+    "index": 275,
+    "pair_id": "F_origin_49_F_table_52_3",
+    "image_paths": [
+      "data/Finance/Table/F_origin_49/F_table_52_3.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_49",
+    "table_id": "F_table_52_3"
+  },
+  {
+    "index": 276,
+    "pair_id": "F_origin_49_F_table_52_4",
+    "image_paths": [
+      "data/Finance/Table/F_origin_49/F_table_52_4.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_49",
+    "table_id": "F_table_52_4"
+  },
+  {
+    "index": 277,
+    "pair_id": "F_origin_49_F_table_52_5",
+    "image_paths": [
+      "data/Finance/Table/F_origin_49/F_table_52_5.png"
+    ],
+    "domain": "Finance",
+    "origin": "F_origin_49",
+    "table_id": "F_table_52_5"
   }
 ]


### PR DESCRIPTION
- Finance 분야에서 생성된 테이블 내 은행/보험 등에 대한 내용에 대해 업체명을 포함하는 경우가 있어 프롬프트를 수정하였습니다.
- QA를 Synthetic 테이블 대상이 아닌 이미지 대상으로 하는 경우가 있어 수정하였습니다. 이제` --skip-qa` 로 테이블을 만들고 regenerate_qa.py 로 새로운 QA 데이터를 만들면 됩니다.